### PR TITLE
data update with existing script

### DIFF
--- a/ufc_fighter_tott.csv
+++ b/ufc_fighter_tott.csv
@@ -1,34 +1,45 @@
 FIGHTER,HEIGHT,WEIGHT,REACH,STANCE,DOB,URL
 Tom Aaron,--,155 lbs.,--,,"Jul 13, 1978",http://ufcstats.com/fighter-details/93fe7332d16c6ad9
 Danny Abbadi,"5' 11""",155 lbs.,--,Orthodox,"Jul 03, 1983",http://ufcstats.com/fighter-details/15df64c02b6b0fde
+Nariman Abbasov,"5' 8""",155 lbs.,"66""",Orthodox,"Feb 01, 1994",http://ufcstats.com/fighter-details/59a9d6dac61c2540
 David Abbott,"6' 0""",265 lbs.,--,Switch,--,http://ufcstats.com/fighter-details/b361180739bed4b0
+Hamdy Abdelwahab,"6' 2""",264 lbs.,"72""",Southpaw,"Jan 22, 1993",http://ufcstats.com/fighter-details/3329d692aea4dc28
+Mansur Abdul-Malik,"6' 2""",185 lbs.,"79""",Orthodox,"Oct 07, 1997",http://ufcstats.com/fighter-details/841695e02c99a521
 Shamil Abdurakhimov,"6' 3""",235 lbs.,"76""",Orthodox,"Sep 02, 1981",http://ufcstats.com/fighter-details/2f5cbecbbe18bac4
 Hiroyuki Abe,"5' 6""",145 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/c0ed7b208197e8de
 Daichi Abe,"5' 11""",170 lbs.,"71""",Orthodox,"Nov 27, 1991",http://ufcstats.com/fighter-details/5140122c3eecd307
 Papy Abedi,"5' 11""",185 lbs.,--,Southpaw,"Jun 30, 1978",http://ufcstats.com/fighter-details/c9f6385af6df66d7
 Ricardo Abreu,"5' 11""",185 lbs.,--,Orthodox,"Apr 27, 1984",http://ufcstats.com/fighter-details/aa6e591c2a2cdecd
 Klidson Abreu,"6' 0""",205 lbs.,"74""",Orthodox,"Dec 24, 1992",http://ufcstats.com/fighter-details/7279654c7674cd24
+Cyborg Abreu,--,--,--,,"Dec 20, 1980",http://ufcstats.com/fighter-details/f689bd7bbd14b392
 Daniel Acacio,"5' 8""",180 lbs.,--,Orthodox,"Dec 27, 1977",http://ufcstats.com/fighter-details/1c5879330d42255f
+John Adajar,"5' 9""",170 lbs.,"75""",Orthodox,"Jun 22, 1991",http://ufcstats.com/fighter-details/989b85f6540c86b1
 Scott Adams,"6' 0""",225 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/2620f3eb21c79614
 Juan Adams,"6' 5""",265 lbs.,"80""",Orthodox,"Jan 16, 1992",http://ufcstats.com/fighter-details/83b00f7597e5ac83
 Anthony Adams,"6' 1""",185 lbs.,"76""",Orthodox,"Jan 13, 1988",http://ufcstats.com/fighter-details/a77633a989013265
 Zarrukh Adashev,"5' 5""",125 lbs.,"65""",Southpaw,"Jul 29, 1992",http://ufcstats.com/fighter-details/79cb2a690b9ba5e8
 Israel Adesanya,"6' 4""",185 lbs.,"80""",Switch,"Jul 22, 1989",http://ufcstats.com/fighter-details/1338e2c7480bdf9e
 Sam Adkins,"6' 3""",225 lbs.,--,Orthodox,"Apr 26, 1965",http://ufcstats.com/fighter-details/0e9869d712e81f8f
+Mohamed Ado,"5' 11""",170 lbs.,"76""",Switch,"May 03, 2000",http://ufcstats.com/fighter-details/7a846fcbf182a7c8
 Nick Agallar,"5' 8""",155 lbs.,--,Orthodox,"Jan 13, 1979",http://ufcstats.com/fighter-details/ebc5af72ad5a28cb
 Mariya Agapova,"5' 6""",125 lbs.,"68""",Southpaw,"Apr 07, 1997",http://ufcstats.com/fighter-details/a08ddd04eaffd81d
+Kantharaj Agasa,--,135 lbs.,--,,"Feb 16, 1992",http://ufcstats.com/fighter-details/26f4288e83188c61
 Marcelo Aguiar,"5' 10""",170 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/44aa652b181bcf68
 Fabio Aguiar,"6' 0""",185 lbs.,--,,"Feb 10, 1988",http://ufcstats.com/fighter-details/501821d7fb7b95c1
 Edwin Aguilar,"5' 10""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/6cadc0a0ba7dc015
 Jessica Aguilar,"5' 3""",115 lbs.,"63""",Orthodox,"May 08, 1982",http://ufcstats.com/fighter-details/8f382b3baa954d2a
 Kevin Aguilar,"5' 7""",155 lbs.,"73""",Orthodox,"Sep 07, 1988",http://ufcstats.com/fighter-details/cf946e03ba2e7666
+Jesus Aguilar,"5' 4""",125 lbs.,"62""",Orthodox,"Mar 13, 1996",http://ufcstats.com/fighter-details/c051c2e12d692b8a
 Christian Aguilera,"5' 9""",170 lbs.,"72""",Switch,"Nov 25, 1991",http://ufcstats.com/fighter-details/ae071698e1a3ccd4
+Nick Aguirre,"5' 9""",135 lbs.,"74""",Southpaw,"Jan 15, 1996",http://ufcstats.com/fighter-details/0978385b2bd9ef9b
 Mike Aina,"5' 9""",155 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/9e3dbb9c68ed5d1a
+Ashiek Ajim,"5' 8""",135 lbs.,"71""",Switch,"Jun 19, 1994",http://ufcstats.com/fighter-details/49dea784f6cfed71
 Hitomi Akano,"5' 4""",135 lbs.,--,Southpaw,"Jul 27, 1974",http://ufcstats.com/fighter-details/2eada40ac8801559
 Omari Akhmedov,"6' 0""",185 lbs.,"73""",Orthodox,"Oct 12, 1987",http://ufcstats.com/fighter-details/16690d100f995f8f
 Yoshihiro Akiyama,"5' 10""",170 lbs.,"75""",Orthodox,"Jul 29, 1975",http://ufcstats.com/fighter-details/b0550072e5f0afa7
 Rostem Akman,"5' 10""",170 lbs.,"72""",Switch,"Dec 19, 1991",http://ufcstats.com/fighter-details/1fc64507a0cb38cf
 Razak Al-Hassan,"6' 2""",205 lbs.,--,Orthodox,"May 14, 1982",http://ufcstats.com/fighter-details/38b50fd1e1b5b656
+Abdul-Kareem Al-Selwady,"5' 8""",155 lbs.,"69""",Orthodox,"Apr 10, 1995",http://ufcstats.com/fighter-details/597499ac7a5aac62
 Mostapha Al-Turk,"6' 2""",245 lbs.,"77""",Orthodox,"Jul 14, 1973",http://ufcstats.com/fighter-details/1cf1310684a841f5
 Herdem Alacabek,"6' 2""",205 lbs.,"75""",Orthodox,"Jun 07, 1991",http://ufcstats.com/fighter-details/7578cc6bd750206b
 Javi Alanis,"5' 6""",135 lbs.,--,,--,http://ufcstats.com/fighter-details/2144954270be834d
@@ -50,10 +61,13 @@ Hector Aldana,"5' 11""",170 lbs.,"72""",Orthodox,"Aug 17, 1988",http://ufcstats.
 Jose Alday,"5' 7""",135 lbs.,"68""",Orthodox,"Sep 14, 1991",http://ufcstats.com/fighter-details/7460ddef986d3144
 Jose Aldo,"5' 7""",135 lbs.,"70""",Orthodox,"Sep 09, 1986",http://ufcstats.com/fighter-details/d0f3959b4a9747e6
 JJ Aldrich,"5' 5""",125 lbs.,"67""",Southpaw,"Sep 29, 1992",http://ufcstats.com/fighter-details/6fd953151d981979
+Irina Alekseeva,"5' 8""",135 lbs.,"67""",Orthodox,"Jun 27, 1990",http://ufcstats.com/fighter-details/103e2e33a60683e1
+Talita Alencar,"5' 1""",115 lbs.,"58""",Orthodox,"Oct 17, 1990",http://ufcstats.com/fighter-details/d35298b6df168456
 Jim Alers,"5' 9""",145 lbs.,"71""",Orthodox,"Oct 14, 1986",http://ufcstats.com/fighter-details/fe5a9547479396ab
 John Alessio,"5' 10""",155 lbs.,"72""",Orthodox,"Jul 05, 1979",http://ufcstats.com/fighter-details/7a15f3694c5cbc02
 Houston Alexander,"6' 0""",205 lbs.,"72""",Orthodox,"Mar 22, 1972",http://ufcstats.com/fighter-details/0541480fbf719d86
 Kenneth Alexander,"5' 9""",155 lbs.,--,Orthodox,"Sep 25, 1977",http://ufcstats.com/fighter-details/8fd76e1b49c00ae2
+Lucas Alexander,"5' 11""",145 lbs.,"73""",Orthodox,"Jul 28, 1995",http://ufcstats.com/fighter-details/11583163f45c7b31
 Marcio Alexandre Junior,"6' 0""",185 lbs.,"75""",Southpaw,"May 05, 1989",http://ufcstats.com/fighter-details/d53482bef23235ba
 Olaf Alfonso,"6' 2""",170 lbs.,--,Orthodox,"Aug 06, 1974",http://ufcstats.com/fighter-details/b757c73f443d4fca
 Pablo Alfonso,"5' 8""",145 lbs.,--,,"May 09, 1983",http://ufcstats.com/fighter-details/4b37a0bc2ab4cae1
@@ -62,24 +76,33 @@ Bill Algeo,"6' 0""",145 lbs.,"73""",Switch,"Jun 09, 1989",http://ufcstats.com/fi
 Royce Alger,"5' 10""",199 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/669a3cb6e394f515
 Amir Aliakbari,"6' 3""",250 lbs.,--,,"Jun 10, 1984",http://ufcstats.com/fighter-details/e17770faae3ca54c
 Sultan Aliev,"5' 11""",170 lbs.,"74""",Orthodox,"Sep 17, 1984",http://ufcstats.com/fighter-details/e70de1859b7ee78e
+Nurullo Aliev,"5' 10""",155 lbs.,"72""",Orthodox,"Dec 08, 2000",http://ufcstats.com/fighter-details/ca28cdf526d6b6e9
+Ikram Aliskerov,"6' 0""",185 lbs.,"76""",Southpaw,"Dec 07, 1992",http://ufcstats.com/fighter-details/b07aed698fba8624
+Leon Aliu,"6' 0""",185 lbs.,"74""",Orthodox,"Jul 14, 1989",http://ufcstats.com/fighter-details/6db394bf6c3b017c
 John Allan,"6' 1""",205 lbs.,"75""",Orthodox,"Feb 22, 1993",http://ufcstats.com/fighter-details/6ebe96a116e79e52
 George Allen,"6' 2""",205 lbs.,--,Open Stance,"Jan 13, 1967",http://ufcstats.com/fighter-details/1e13936d708bcff7
 Arnold Allen,"5' 8""",145 lbs.,"70""",Southpaw,"Jan 22, 1994",http://ufcstats.com/fighter-details/040a74bb0a465c54
 Brendan Allen,"6' 2""",185 lbs.,"75""",Orthodox,"Dec 28, 1995",http://ufcstats.com/fighter-details/2f181c0467965b98
+Daniel Allen,"6' 0""",155 lbs.,"75""",Southpaw,"Aug 10, 1992",http://ufcstats.com/fighter-details/adf9a901308fb8e3
 Ben Alloway,"5' 11""",170 lbs.,"76""",Orthodox,"Feb 19, 1981",http://ufcstats.com/fighter-details/c4fe2e9a06ea5bcb
+Asu Almabayev,"5' 4""",125 lbs.,"65""",Orthodox,"Jan 25, 1994",http://ufcstats.com/fighter-details/8d3273573b85be09
+Bekzat Almakhan,"5' 7""",135 lbs.,"68""",Orthodox,"Oct 08, 1997",http://ufcstats.com/fighter-details/a4dc0f2b95df4cc1
+John Dave Almanza,"5' 7""",125 lbs.,"67""",Southpaw,"Mar 22, 2004",http://ufcstats.com/fighter-details/088aa1b19b2dc14a
 Ricardo Almeida,"6' 0""",170 lbs.,"74""",Orthodox,"Nov 29, 1976",http://ufcstats.com/fighter-details/91186547a7f3f758
 Magno Almeida,"6' 0""",155 lbs.,--,,"Jun 06, 1985",http://ufcstats.com/fighter-details/d615d6a10a4704cd
 Thomas Almeida,"5' 7""",145 lbs.,"70""",Southpaw,"Jul 31, 1991",http://ufcstats.com/fighter-details/2b074403b7c6cdb4
 Ericka Almeida,"5' 6""",115 lbs.,--,Orthodox,"Mar 05, 1989",http://ufcstats.com/fighter-details/67a992d4cff22466
 Estefani Almeida,"5' 4""",125 lbs.,--,Orthodox,"Oct 17, 1988",http://ufcstats.com/fighter-details/f16ddfa31236efed
 Jailton Almeida,"6' 3""",205 lbs.,"79""",Orthodox,"Jun 26, 1991",http://ufcstats.com/fighter-details/41e83a89929d1327
-Lucas Almeida,"5' 11""",155 lbs.,"71""",Orthodox,"Jan 13, 1991",http://ufcstats.com/fighter-details/710f0f8c5d5c9d41
+Lucas Almeida,"5' 11""",145 lbs.,"71""",Orthodox,"Jan 31, 1991",http://ufcstats.com/fighter-details/710f0f8c5d5c9d41
+Cesar Almeida,"6' 1""",185 lbs.,"74""",Orthodox,"Mar 28, 1988",http://ufcstats.com/fighter-details/64d47ef881a437a4
 Mauricio Alonso,"6' 2""",170 lbs.,--,,"Feb 27, 1980",http://ufcstats.com/fighter-details/c6bf75775b278ed8
 Sarah Alpar,"5' 4""",135 lbs.,"63""",Southpaw,"Jun 01, 1991",http://ufcstats.com/fighter-details/49b130de1da2e1bf
 Ali AlQaisi,"5' 6""",135 lbs.,"68""",Orthodox,"Sep 23, 1990",http://ufcstats.com/fighter-details/e87a13e02c01331d
 Rico Altamirano,"5' 10""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/c61b49cec6abd6b9
 Victor Altamirano,"5' 8""",125 lbs.,"70""",Switch,"Jan 23, 1991",http://ufcstats.com/fighter-details/dc7927cd622676a7
 Mike Altman,"5' 10""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/c11036da9162cb5f
+Patricia Alujas,"5' 4""",115 lbs.,"64""",Orthodox,"May 08, 1996",http://ufcstats.com/fighter-details/430c533614d45813
 Sean Alvarez,"6' 0""",235 lbs.,--,Orthodox,"Jul 14, 1971",http://ufcstats.com/fighter-details/e741536153227386
 Eddie Alvarez,"5' 9""",155 lbs.,"69""",Orthodox,"Jan 11, 1984",http://ufcstats.com/fighter-details/33a331684283900f
 Jaime Alvarez,"5' 8""",125 lbs.,"69""",Orthodox,"Mar 08, 1988",http://ufcstats.com/fighter-details/4438482bd1d5a029
@@ -87,7 +110,7 @@ Joel Alvarez,"6' 3""",155 lbs.,"77""",Orthodox,"Mar 02, 1993",http://ufcstats.co
 Thiago Alves,"5' 9""",170 lbs.,"70""",Orthodox,"Oct 03, 1983",http://ufcstats.com/fighter-details/31ee470ef5dc8d7f
 Anthony Alves,--,--,--,,--,http://ufcstats.com/fighter-details/bd92cf5da5413d2a
 Amilcar Alves,"6' 0""",170 lbs.,--,Southpaw,"Aug 08, 1988",http://ufcstats.com/fighter-details/dc5a6b2fdb27e7dc
-Warlley Alves,"5' 11""",170 lbs.,"72""",Orthodox,"Jan 04, 1991",http://ufcstats.com/fighter-details/d317a5e2b3f88c5f
+Warlley Alves,"5' 11""",185 lbs.,"72""",Orthodox,"Jan 04, 1991",http://ufcstats.com/fighter-details/d317a5e2b3f88c5f
 Rafael Alves,"5' 8""",155 lbs.,"68""",Orthodox,"Nov 14, 1990",http://ufcstats.com/fighter-details/029afd138865d20a
 Sam Alvey,"6' 2""",185 lbs.,"75""",Southpaw,"May 06, 1986",http://ufcstats.com/fighter-details/d156513a19acf856
 Andre Amado,"6' 0""",154 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/20821819c401ced8
@@ -97,7 +120,10 @@ Chris Amarante,--,185 lbs.,--,,--,http://ufcstats.com/fighter-details/ee0b69e307
 Jimmy Ambriz,"6' 2""",315 lbs.,--,Southpaw,"Jan 26, 1970",http://ufcstats.com/fighter-details/c912f676692c353a
 JJ Ambrose,"5' 10""",170 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/d562b12b8fe88336
 Alen Amedovski,"5' 10""",185 lbs.,"74""",Orthodox,"Apr 06, 1988",http://ufcstats.com/fighter-details/70fa1c64a2c439ef
+Hyder Amil,"5' 9""",145 lbs.,"70""",Switch,"May 28, 1990",http://ufcstats.com/fighter-details/41cc71cbf210e0fe
+Hamid Amiri,--,145 lbs.,--,,"Jun 15, 2003",http://ufcstats.com/fighter-details/6c40705cf6c0d7e2
 Makwan Amirkhani,"5' 10""",145 lbs.,"72""",Southpaw,"Nov 08, 1988",http://ufcstats.com/fighter-details/87a1dc546b1c5caf
+Jaqueline Amorim,"5' 3""",115 lbs.,"68""",Orthodox,"Jun 24, 1995",http://ufcstats.com/fighter-details/bc7d1ad49fcb2d08
 Bertrand Amoussou,"5' 8""",190 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/53adf5b845d91e4a
 Karl Amoussou,"5' 11""",185 lbs.,--,Orthodox,"Nov 21, 1985",http://ufcstats.com/fighter-details/23a8c33869bf5392
 Eryk Anders,"6' 1""",185 lbs.,"75""",Southpaw,"Apr 21, 1987",http://ufcstats.com/fighter-details/cad24459b28592ca
@@ -107,12 +133,17 @@ Lowell Anderson,"5' 6""",160 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-det
 Corey Anderson,"6' 3""",205 lbs.,"79""",Orthodox,"Sep 22, 1989",http://ufcstats.com/fighter-details/5e4eec08896c9423
 Derek Anderson,"6' 0""",155 lbs.,--,,"Feb 02, 1990",http://ufcstats.com/fighter-details/19ba965651486013
 Megan Anderson,"6' 0""",145 lbs.,"72""",Orthodox,"Feb 11, 1990",http://ufcstats.com/fighter-details/a0e75f4a13eb73f1
+Liam Anderson,"6' 3""",185 lbs.,"75""",Orthodox,"Jan 13, 1995",http://ufcstats.com/fighter-details/b03a0c78ca45facf
+Tatsuya Ando,"5' 4""",145 lbs.,"68""",Southpaw,"Apr 26, 1990",http://ufcstats.com/fighter-details/17615148dd4be6f6
 Alex Andrade,"5' 11""",200 lbs.,--,Orthodox,"May 14, 1974",http://ufcstats.com/fighter-details/1562b12763cc8d67
 Jessica Andrade,"5' 1""",125 lbs.,"62""",Orthodox,"Sep 25, 1991",http://ufcstats.com/fighter-details/6a1901c62ab3870f
 Viscardi Andrade,"5' 11""",170 lbs.,"75""",Orthodox,"Mar 08, 1984",http://ufcstats.com/fighter-details/d221ee27afc7a60e
 Jermaine Andre,"5' 7""",200 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/9bad58fa651d6196
+Juan Andres Luna,"5' 7""",125 lbs.,"72""",Orthodox,"Aug 20, 1995",http://ufcstats.com/fighter-details/1fd9f744105024a8
+Fellipe Andrew,--,--,--,,"Oct 24, 1994",http://ufcstats.com/fighter-details/7977fb0fd9c5955d
 Dylan Andrews,"6' 1""",185 lbs.,"74""",Switch,"Nov 15, 1979",http://ufcstats.com/fighter-details/00debc804e2b1cd4
 Reese Andy,"6' 0""",205 lbs.,--,Orthodox,"Mar 31, 1973",http://ufcstats.com/fighter-details/46e2ca71fd5089cb
+Angga,"5' 7""",145 lbs.,"68""",Orthodox,"Jan 13, 1989",http://ufcstats.com/fighter-details/d6a3e131ad4ba064
 Julius Anglickas,"6' 3""",205 lbs.,--,Orthodox,"Jul 23, 1991",http://ufcstats.com/fighter-details/e20ad078a7d63361
 Collin Anglin,"5' 9""",145 lbs.,"71""",Orthodox,"Feb 20, 1993",http://ufcstats.com/fighter-details/047a91d3d9c79b05
 Chad Anheliger,"5' 6""",135 lbs.,"64""",Orthodox,"Dec 01, 1986",http://ufcstats.com/fighter-details/c7c39e2fb70248b3
@@ -121,10 +152,11 @@ Magomed Ankalaev,"6' 3""",205 lbs.,"75""",Orthodox,"Jun 02, 1992",http://ufcstat
 Gadzhimurad Antigulov,"5' 11""",205 lbs.,"70""",Orthodox,"Feb 09, 1987",http://ufcstats.com/fighter-details/af997f7611673880
 Adam Antolin,"5' 5""",125 lbs.,"63""",Orthodox,"Feb 28, 1982",http://ufcstats.com/fighter-details/25b31165758402dd
 Angelo Antonio,--,205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/dbd198f780286aca
+Vanilto Antunes,"6' 0""",170 lbs.,"72""",Orthodox,"Dec 28, 1994",http://ufcstats.com/fighter-details/cc49ada1ea955b13
 Azunna Anyanwu,"6' 1""",251 lbs.,--,Orthodox,"Aug 05, 1981",http://ufcstats.com/fighter-details/78d48d3874dacafd
 Shinsho Anzai,"5' 7""",170 lbs.,"70""",Orthodox,"Dec 01, 1985",http://ufcstats.com/fighter-details/4665f9f909cd7214
 Shinya Aoki,"5' 11""",154 lbs.,--,Southpaw,"May 09, 1983",http://ufcstats.com/fighter-details/79ded75550efc139
-Aoriqileng,"5' 7""",125 lbs.,"69""",Orthodox,"Jun 25, 1993",http://ufcstats.com/fighter-details/7d420039bbfe7c1a
+Aoriqileng,"5' 7""",135 lbs.,"69""",Orthodox,"Jun 25, 1993",http://ufcstats.com/fighter-details/7d420039bbfe7c1a
 Josh Appelt,"5' 10""",255 lbs.,--,Southpaw,"Jun 19, 1983",http://ufcstats.com/fighter-details/0c1a04afca64e38f
 Erik Apple,"6' 0""",170 lbs.,--,Orthodox,"Aug 26, 1977",http://ufcstats.com/fighter-details/1ccff7f0cfdf85eb
 Kenji Arai,"5' 10""",145 lbs.,--,Southpaw,"Oct 05, 1979",http://ufcstats.com/fighter-details/269d103c96a4c3a5
@@ -134,12 +166,18 @@ Igor Araujo,"6' 1""",170 lbs.,"77""",Orthodox,"Dec 06, 1980",http://ufcstats.com
 Viviane Araujo,"5' 4""",125 lbs.,"68""",Orthodox,"Nov 21, 1986",http://ufcstats.com/fighter-details/36541f1e6c5d4955
 Julio Arce,"5' 7""",145 lbs.,"70""",Southpaw,"Oct 27, 1989",http://ufcstats.com/fighter-details/1291edf2d566a71a
 Art Arciniega,"5' 8""",145 lbs.,--,,"Oct 15, 1981",http://ufcstats.com/fighter-details/d25e39e74efb0a77
+Alice Ardelean,"5' 3""",115 lbs.,"62""",Orthodox,"Apr 19, 1992",http://ufcstats.com/fighter-details/87f8699fdcc2c404
 Tristan Arenal,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/9c9455912d917e4e
+Gabriel Arges,--,170 lbs.,--,,"Jan 29, 1993",http://ufcstats.com/fighter-details/db3c4a884d704efe
+Dan Argueta,"5' 7""",135 lbs.,"68""",Southpaw,"Aug 13, 1993",http://ufcstats.com/fighter-details/e4ba58725825412d
+Reza Arianto,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/90063913321e7670
 Hashem Arkhagha,"6' 2""",185 lbs.,"75""",Orthodox,"Sep 11, 1989",http://ufcstats.com/fighter-details/9a7ffa80766caa51
 Andrei Arlovski,"6' 3""",240 lbs.,"77""",Orthodox,"Feb 04, 1979",http://ufcstats.com/fighter-details/3738e68d2261e60f
+Garrett Armfield,"5' 6""",135 lbs.,"70""",Orthodox,"Oct 09, 1996",http://ufcstats.com/fighter-details/1effd880e1f1bb30
 Joey Armstrong,--,--,--,,--,http://ufcstats.com/fighter-details/30ad2050273d016a
 Austin Arnett,"6' 0""",145 lbs.,"72""",Orthodox,"Oct 22, 1991",http://ufcstats.com/fighter-details/bf0e700106d00e55
 Ricardo Arona,"5' 11""",205 lbs.,--,Orthodox,"Jul 17, 1978",http://ufcstats.com/fighter-details/05fbfe628658c538
+Eli Aronov,"5' 10""",185 lbs.,"72""",Orthodox,"Jun 06, 1996",http://ufcstats.com/fighter-details/a90c200c3fbb22c4
 Chalid Arrab,"5' 11""",205 lbs.,--,Orthodox,"May 28, 1975",http://ufcstats.com/fighter-details/770b9d4813c25902
 Akbarh Arreola,"5' 10""",155 lbs.,"71""",Southpaw,"Jan 14, 1983",http://ufcstats.com/fighter-details/c136b2a8852da5bd
 Matt Arroyo,"5' 10""",170 lbs.,"72""",Orthodox,"Sep 01, 1982",http://ufcstats.com/fighter-details/de62052b2ede65ba
@@ -147,19 +185,23 @@ Antonio Arroyo,"6' 3""",185 lbs.,"73""",Orthodox,"Jul 01, 1989",http://ufcstats.
 Gilles Arsene,"5' 9""",190 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/2dea80c069847321
 Veta Arteaga,"5' 7""",125 lbs.,--,,--,http://ufcstats.com/fighter-details/91e3388e69060e69
 Cesar Arzamendia,"5' 11""",155 lbs.,--,Orthodox,"Jan 31, 1991",http://ufcstats.com/fighter-details/49f78022126bf4a4
+Kai Asakura,--,125 lbs.,--,,"Oct 31, 1993",http://ufcstats.com/fighter-details/d33da8a3d82bdb62
 Teddy Ash,"6' 1""",185 lbs.,"73""",Switch,"Dec 27, 1989",http://ufcstats.com/fighter-details/a373085066dbfb54
 Arman Ashimov,"5' 6""",125 lbs.,--,,"Jan 14, 1992",http://ufcstats.com/fighter-details/d26a0988c9dc9886
+Yanal Ashmouz,"5' 9""",155 lbs.,"69""",Orthodox,"Mar 31, 1995",http://ufcstats.com/fighter-details/c739c2995a275314
+Asjabharan,"5' 6""",135 lbs.,--,,"Jul 31, 1992",http://ufcstats.com/fighter-details/8be9deb7d6b36354
 Askar Askar,"5' 7""",145 lbs.,"69""",Orthodox,"Aug 19, 1994",http://ufcstats.com/fighter-details/2abc414136504554
 Askar Askarov,"5' 6""",125 lbs.,"67""",Orthodox,"Oct 09, 1992",http://ufcstats.com/fighter-details/b1d19449397541dc
 Cyril Asker,"6' 0""",247 lbs.,"74""",Orthodox,"Dec 24, 1985",http://ufcstats.com/fighter-details/9be6020024133293
-Khusein Askhabov,"5' 8""",145 lbs.,--,,"Feb 13, 1995",http://ufcstats.com/fighter-details/5c10da56d712ac9c
+Khusein Askhabov,"5' 8""",145 lbs.,"69""",Orthodox,"Feb 13, 1995",http://ufcstats.com/fighter-details/5c10da56d712ac9c
 Scott Askham,"6' 3""",185 lbs.,"75""",Southpaw,"May 20, 1988",http://ufcstats.com/fighter-details/06827d70c53ff0d9
 Ben Askren,"5' 11""",170 lbs.,"73""",Orthodox,"Jul 18, 1984",http://ufcstats.com/fighter-details/0b31f87be71ebbb1
-Ibo Aslan,"6' 3""",205 lbs.,--,,"Apr 23, 1996",http://ufcstats.com/fighter-details/6e8f1bcdda94ff45
+Ibo Aslan,"6' 3""",205 lbs.,"77""",Orthodox,"Apr 23, 1996",http://ufcstats.com/fighter-details/6e8f1bcdda94ff45
 Tom Aspinall,"6' 5""",256 lbs.,"78""",Orthodox,"Apr 11, 1993",http://ufcstats.com/fighter-details/399afbabc02376b5
 Bruno Assis,"6' 2""",185 lbs.,--,Orthodox,"May 23, 1992",http://ufcstats.com/fighter-details/ff222167cce02919
 Junior Assuncao,"5' 9""",145 lbs.,"72""",Orthodox,"Jun 24, 1981",http://ufcstats.com/fighter-details/d0d7160824278840
 Raphael Assuncao,"5' 5""",135 lbs.,"66""",Orthodox,"Jul 19, 1982",http://ufcstats.com/fighter-details/2f13e4020cea5b38
+Michael Aswell,"5' 8""",145 lbs.,"69""",Orthodox,"Sep 27, 2000",http://ufcstats.com/fighter-details/01c9e4013afce141
 Bazigit Atajev,"6' 1""",230 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/fd7acf42bd6e7e95
 Rich Attonito,"5' 10""",170 lbs.,"72""",Orthodox,"Jun 16, 1977",http://ufcstats.com/fighter-details/210935fd21670f6d
 Olivier Aubin-Mercier,"5' 9""",155 lbs.,"70""",Southpaw,"Feb 23, 1989",http://ufcstats.com/fighter-details/55ee431411ccf07a
@@ -182,6 +224,7 @@ Luciano Azevedo,"6' 3""",161 lbs.,--,Orthodox,"Jun 25, 1981",http://ufcstats.com
 Hunter Azure,"5' 8""",145 lbs.,"69""",Orthodox,"Mar 02, 1992",http://ufcstats.com/fighter-details/2af2f2e26c4c0402
 Niklas Backstrom,"6' 1""",145 lbs.,--,Orthodox,"Aug 22, 1989",http://ufcstats.com/fighter-details/39cc64bf0a269db9
 Seth Baczynski,"6' 3""",170 lbs.,"75""",Orthodox,"Oct 26, 1981",http://ufcstats.com/fighter-details/fd5b6598a3b70c0a
+Abdul Azeem Badakhshi,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/968764372c49eab6
 Ryan Bader,"6' 2""",205 lbs.,"74""",Orthodox,"Jun 07, 1983",http://ufcstats.com/fighter-details/c0ab242c40decc55
 Izabela Badurek,"5' 5""",115 lbs.,--,Orthodox,"Jul 11, 1991",http://ufcstats.com/fighter-details/4fcf6e0c4e0e6664
 Miguel Baeza,"6' 2""",170 lbs.,"74""",Orthodox,"Aug 23, 1992",http://ufcstats.com/fighter-details/82d4c957649faf9b
@@ -190,25 +233,30 @@ Mehdi Baghdad,"6' 1""",155 lbs.,--,Orthodox,"Apr 13, 1985",http://ufcstats.com/f
 Melsik Baghdasaryan,"5' 9""",145 lbs.,"70""",Southpaw,"Jan 28, 1992",http://ufcstats.com/fighter-details/a52bc1e62cf0b7c6
 Siyar Bahadurzada,"5' 11""",170 lbs.,"73""",Orthodox,"Apr 17, 1984",http://ufcstats.com/fighter-details/aec185309b4843d0
 Ignacio Bahamondes,"6' 3""",155 lbs.,"75""",Orthodox,"Aug 27, 1997",http://ufcstats.com/fighter-details/e4a47b07044ddd72
+Bahatebole Batebolati,"5' 8""",170 lbs.,"71""",Southpaw,"Sep 12, 1997",http://ufcstats.com/fighter-details/8f313e9c3a39c06e
 Shamar Bailey,"5' 9""",155 lbs.,"75""",Southpaw,"Sep 22, 1982",http://ufcstats.com/fighter-details/e2b8186b618b00c4
 Jordan Bailey,"5' 9""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/34dbcd4dbaf21a36
 Scott Baker,"6' 0""",210 lbs.,--,,--,http://ufcstats.com/fighter-details/7d5b12de1625984e
 Bryan Baker,"6' 3""",185 lbs.,--,Orthodox,"Oct 13, 1985",http://ufcstats.com/fighter-details/898337ef520fe4d3
 Jin Bala,"5' 9""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/371efa53bd0cf669
+Balajin,"5' 9""",145 lbs.,"72""",Orthodox,"Mar 31, 1992",http://ufcstats.com/fighter-details/e626e92a8f2a9737
 Oluwale Bamgbose,"5' 11""",185 lbs.,"78""",Switch,"Aug 04, 1987",http://ufcstats.com/fighter-details/04b39f4e8eb59d7c
 Stephen Banaszak,"6' 0""",145 lbs.,--,,"Dec 07, 1990",http://ufcstats.com/fighter-details/4c4b44e3cf5815b3
 Marcin Bandel,"5' 10""",155 lbs.,--,Orthodox,"Oct 10, 1989",http://ufcstats.com/fighter-details/5c2ce761399dc9c5
 Humberto Bandenay,"5' 11""",145 lbs.,"71""",Southpaw,"Sep 04, 1994",http://ufcstats.com/fighter-details/2c2caf2f2bab9df5
 Tae Hyun Bang,"5' 9""",155 lbs.,"71""",Switch,"Apr 15, 1983",http://ufcstats.com/fighter-details/9a2d3567abc02e34
 Yohan Banks,--,--,--,,--,http://ufcstats.com/fighter-details/c50ea21fe9ef478d
+Shauna Bannon,"5' 5""",115 lbs.,"65""",Switch,"Oct 23, 1993",http://ufcstats.com/fighter-details/9c442aaf149ea982
 Antonio Banuelos,"5' 5""",135 lbs.,"63""",Orthodox,"Sep 23, 1979",http://ufcstats.com/fighter-details/9ddfb3369a3b0394
 Renan Barao,"5' 6""",145 lbs.,"70""",Orthodox,"Jan 31, 1987",http://ufcstats.com/fighter-details/2c99576fefe53c7c
 Junior Barata,"5' 10""",170 lbs.,--,Orthodox,"Jan 25, 1982",http://ufcstats.com/fighter-details/06dced58ca24a6bd
 Maycee Barber,"5' 5""",125 lbs.,"65""",Switch,"May 18, 1998",http://ufcstats.com/fighter-details/6a740daf1b279661
-Bryan Barberena,"6' 0""",170 lbs.,"72""",Southpaw,"May 03, 1989",http://ufcstats.com/fighter-details/a331233f597090a5
+Bryan Barberena,"6' 0""",185 lbs.,"72""",Southpaw,"May 03, 1989",http://ufcstats.com/fighter-details/a331233f597090a5
+Dione Barbosa,"5' 6""",125 lbs.,"66""",Orthodox,"May 08, 1992",http://ufcstats.com/fighter-details/27b388f0aab49780
 Edson Barboza,"5' 11""",145 lbs.,"75""",Orthodox,"Jan 21, 1986",http://ufcstats.com/fighter-details/64a50dad704d1d49
 Raoni Barcelos,"5' 7""",135 lbs.,"67""",Orthodox,"May 01, 1987",http://ufcstats.com/fighter-details/b9f28e7045fdfce7
 Daniel Barez,"5' 6""",125 lbs.,"66""",Orthodox,"Dec 10, 1988",http://ufcstats.com/fighter-details/e8fe9c15d348e778
+Danny Barlow,"6' 2""",170 lbs.,"79""",Southpaw,"Aug 02, 1995",http://ufcstats.com/fighter-details/b7c5eb7cdbac6a63
 Luke Barnatt,"6' 6""",185 lbs.,"77""",Orthodox,"Apr 13, 1988",http://ufcstats.com/fighter-details/172c2135e70f87b7
 James Barnes,"5' 8""",135 lbs.,"71""",Orthodox,"May 28, 1982",http://ufcstats.com/fighter-details/c06a5c95f1169c0b
 Nick Barnes,"5' 11""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/78a5eea49638685d
@@ -228,30 +276,37 @@ Alexandre Barros,"5' 9""",170 lbs.,--,Southpaw,"Nov 19, 1976",http://ufcstats.co
 Ricardo Barros,"6' 1""",205 lbs.,--,,"Mar 22, 1976",http://ufcstats.com/fighter-details/d26394fc0e8e880a
 Francimar Barroso,"6' 1""",205 lbs.,"75""",Orthodox,"Feb 28, 1980",http://ufcstats.com/fighter-details/b69f24c500d783e7
 Pat Barry,"5' 11""",235 lbs.,"74""",Orthodox,"Jul 07, 1979",http://ufcstats.com/fighter-details/658c3465581ae46b
-Dean Barry,--,155 lbs.,--,,"Mar 07, 1992",http://ufcstats.com/fighter-details/a6f3d15cb84334bb
+Dean Barry,"5' 10""",170 lbs.,"72""",Orthodox,"Jul 03, 1992",http://ufcstats.com/fighter-details/a6f3d15cb84334bb
 Enrique Barzola,"5' 7""",145 lbs.,"70""",Orthodox,"Apr 28, 1989",http://ufcstats.com/fighter-details/be0b310a12eb80b4
 Javid Basharat,"5' 9""",135 lbs.,"69""",Orthodox,"Sep 07, 1995",http://ufcstats.com/fighter-details/bbab3baf66128ae2
+Farid Basharat,"5' 8""",135 lbs.,"71""",Orthodox,"Aug 02, 1997",http://ufcstats.com/fighter-details/a09ed60aa67a3f67
+Austin Bashi,"5' 6""",145 lbs.,"70""",Orthodox,"Sep 29, 2001",http://ufcstats.com/fighter-details/d3f89fa685bd8420
 Stephen Bass,"5' 9""",145 lbs.,--,Orthodox,"Nov 14, 1982",http://ufcstats.com/fighter-details/1cecc8fe6748a532
 Sean Bassett,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/2c733e059462c1dc
 Ryan Bastianelli,"5' 5""",135 lbs.,--,,--,http://ufcstats.com/fighter-details/29508aff4d93cbbe
 Shayna Baszler,"5' 7""",135 lbs.,--,Orthodox,"Aug 08, 1980",http://ufcstats.com/fighter-details/8ef4a91ac694b7ce
 Michel Batista,"6' 3""",260 lbs.,--,Orthodox,"Apr 20, 1984",http://ufcstats.com/fighter-details/34218661c44ed55d
-Bryan Battle,"6' 1""",185 lbs.,"77""",Orthodox,"Sep 21, 1994",http://ufcstats.com/fighter-details/f626118b6da0e020
+Bryan Battle,"6' 1""",170 lbs.,"77""",Orthodox,"Sep 21, 1994",http://ufcstats.com/fighter-details/f626118b6da0e020
 Alan Baudot,"6' 3""",243 lbs.,"79""",Orthodox,"Feb 01, 1988",http://ufcstats.com/fighter-details/c9a94278df042f46
 Mario Bautista,"5' 9""",135 lbs.,"69""",Switch,"Jul 01, 1993",http://ufcstats.com/fighter-details/bc711b6dd95c1af6
 Chris Beal,"5' 7""",125 lbs.,"69""",Orthodox,"Aug 06, 1985",http://ufcstats.com/fighter-details/55f446032177b119
+Donovan Beard,"6' 2""",185 lbs.,"78""",Orthodox,"Nov 05, 1989",http://ufcstats.com/fighter-details/3a6ac598320ca7f2
 Rudy Bears,"5' 11""",170 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/74f13066b1417ef3
 Salvador Becerra,"5' 9""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/4fd76e7ba8313457
 Ariel Beck,"5' 6""",125 lbs.,"66""",Southpaw,"Sep 16, 1990",http://ufcstats.com/fighter-details/b96939f2b8d88e82
 Jeff Bedard,"5' 6""",145 lbs.,--,Orthodox,"Feb 06, 1970",http://ufcstats.com/fighter-details/93bf96be327fcd98
 Eric Bedard,"6' 2""",239 lbs.,--,,"Sep 11, 1984",http://ufcstats.com/fighter-details/ce05955c26c3c090
 Johnny Bedford,"5' 10""",135 lbs.,"71""",Orthodox,"Jan 06, 1983",http://ufcstats.com/fighter-details/ffc3e6daaa6da0b7
+Rolando Bedoya,"5' 11""",155 lbs.,"74""",Orthodox,"Jan 13, 1997",http://ufcstats.com/fighter-details/40a456a25d52ee65
 Chase Beebe,"5' 7""",135 lbs.,"67""",Orthodox,"Mar 29, 1985",http://ufcstats.com/fighter-details/b16a7e6a627e9789
 Lyle Beerbohm,"5' 10""",155 lbs.,--,Southpaw,"Feb 05, 1979",http://ufcstats.com/fighter-details/babc6b5745335f18
+Allan Begosso,"5' 5""",135 lbs.,"66""",Orthodox,"Nov 23, 1995",http://ufcstats.com/fighter-details/d6ed764f8b78d32a
 Mirsad Bektic,"5' 8""",145 lbs.,"70""",Orthodox,"Feb 16, 1991",http://ufcstats.com/fighter-details/cbd3e590a85b18c5
-Diana Belbita,"5' 7""",125 lbs.,"68""",Orthodox,"Jun 26, 1996",http://ufcstats.com/fighter-details/d7e40dca3ae125be
+Diana Belbita,"5' 7""",115 lbs.,"68""",Orthodox,"Jun 26, 1996",http://ufcstats.com/fighter-details/d7e40dca3ae125be
 Alan Belcher,"6' 2""",185 lbs.,"75""",Orthodox,"Apr 24, 1984",http://ufcstats.com/fighter-details/4130a743d9d22163
 Vitor Belfort,"6' 0""",185 lbs.,"74""",Southpaw,"Apr 01, 1977",http://ufcstats.com/fighter-details/0ee783aa00e468f0
+Yousri Belgaroui,"6' 5""",185 lbs.,"79""",Orthodox,"Jun 02, 1992",http://ufcstats.com/fighter-details/7674b836ce0698a0
+Rodolfo Bellato,"6' 3""",205 lbs.,"77""",Orthodox,"Feb 05, 1996",http://ufcstats.com/fighter-details/69898645d600abdb
 Danilo Belluardo,"6' 0""",155 lbs.,"74""",Southpaw,"Jul 21, 1994",http://ufcstats.com/fighter-details/c3f6db17cea09ca7
 Joey Beltran,"6' 1""",185 lbs.,"75""",Orthodox,"Dec 08, 1981",http://ufcstats.com/fighter-details/46baf0f57edfa4df
 Marco Beltran,"5' 8""",125 lbs.,"69""",Orthodox,"May 18, 1986",http://ufcstats.com/fighter-details/ec71a892fada28c7
@@ -263,6 +318,7 @@ Gabriel Benitez,"5' 8""",155 lbs.,"71""",Southpaw,"Jun 15, 1988",http://ufcstats
 Charles Bennett,"5' 8""",155 lbs.,--,Orthodox,"Nov 23, 1979",http://ufcstats.com/fighter-details/8dc4f34c1f50d00d
 Josh Bennett,"6' 4""",259 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/c3ac8d0da7b05772
 DeAnna Bennett,"5' 4""",125 lbs.,"68""",Orthodox,"Nov 18, 1984",http://ufcstats.com/fighter-details/404ecb2700844072
+Benjamin Bennett,"6' 0""",170 lbs.,"73""",Switch,"May 08, 1994",http://ufcstats.com/fighter-details/7030c27fc9778964
 Lance Benoist,"5' 11""",170 lbs.,"72""",Southpaw,"Aug 26, 1988",http://ufcstats.com/fighter-details/5431dccc09118234
 Joe Benoit,"5' 9""",170 lbs.,--,Orthodox,"Mar 12, 1982",http://ufcstats.com/fighter-details/a30f6d375dea5f9b
 Ryan Benoit,"5' 5""",125 lbs.,"68""",Orthodox,"Aug 25, 1989",http://ufcstats.com/fighter-details/20999e27ddd94bda
@@ -289,14 +345,17 @@ Arjan Bhullar,"6' 1""",245 lbs.,"75""",Orthodox,"May 13, 1986",http://ufcstats.c
 KB Bhullar,"6' 4""",185 lbs.,"78""",Switch,"Oct 12, 1991",http://ufcstats.com/fighter-details/9cd047a828dd7515
 Bibulatov Magomed,"5' 5""",125 lbs.,"65""",Orthodox,"Aug 22, 1988",http://ufcstats.com/fighter-details/87f19d19f4cb73f8
 David Bielkheden,"5' 10""",155 lbs.,"71""",Orthodox,"Jun 06, 1979",http://ufcstats.com/fighter-details/1efa064872f089d0
+Blake Bilder,"5' 8""",145 lbs.,"68""",Switch,"Jul 12, 1990",http://ufcstats.com/fighter-details/5095b0920a3602aa
 Jonas Bilharinho,"5' 11""",145 lbs.,"75""",Switch,"May 22, 1990",http://ufcstats.com/fighter-details/ebbf571f349e79d9
 Jeremiah Billington,"5' 9""",205 lbs.,--,Orthodox,"Nov 14, 1977",http://ufcstats.com/fighter-details/b3b6e80b7d5f8f0d
 Scott Bills,"5' 10""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/53f02bbc41d99432
 Anthony Birchak,"5' 8""",135 lbs.,"69""",Orthodox,"May 16, 1986",http://ufcstats.com/fighter-details/c5a126ace82a6025
 Chris Birchler,"6' 3""",205 lbs.,--,Switch,"Jun 05, 1987",http://ufcstats.com/fighter-details/8a22c6b4d29880a3
+Angad Bisht,"5' 7""",125 lbs.,"67""",Orthodox,"Jun 05, 1995",http://ufcstats.com/fighter-details/7b4ae3fd439a05b6
 Michael Bisping,"6' 1""",185 lbs.,"75""",Orthodox,"Feb 28, 1979",http://ufcstats.com/fighter-details/2b93ebd9f5417ad2
 Amaury Bitetti,"5' 9""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/7a359ef685a304a7
 Caio Bittencourt,"6' 0""",185 lbs.,"75""",Orthodox,"May 22, 1991",http://ufcstats.com/fighter-details/a653cb5eb4b39339
+Davi Bittencourt,"5' 5""",135 lbs.,"65""",Orthodox,"Oct 12, 1994",http://ufcstats.com/fighter-details/dd6ec6f941c3a414
 Simon Biyong,--,205 lbs.,--,,"Apr 05, 1991",http://ufcstats.com/fighter-details/27ab7257bf6a3b65
 Jan Blachowicz,"6' 2""",205 lbs.,"78""",Orthodox,"Feb 24, 1983",http://ufcstats.com/fighter-details/99df7d0a2a08a8a8
 Jason Black,"5' 8""",155 lbs.,--,Orthodox,"Jul 15, 1972",http://ufcstats.com/fighter-details/b2f743746e8dcfa2
@@ -304,10 +363,13 @@ Brad Blackburn,"5' 10""",170 lbs.,"73""",Orthodox,"May 25, 1977",http://ufcstats
 Jason Blackford,--,--,--,,--,http://ufcstats.com/fighter-details/619d807fa54ae8f7
 Tom Blackledge,--,205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/2adb11835acd815b
 Sherrard Blackledge,"5' 11""",155 lbs.,"75""",Orthodox,"Aug 16, 1993",http://ufcstats.com/fighter-details/0e5c79b3594ff0ad
+Da'Mon Blackshear,"5' 10""",135 lbs.,"72""",Switch,"Aug 12, 1994",http://ufcstats.com/fighter-details/da22387a0407a2dc
+Chasen Blair,"5' 10""",155 lbs.,"71""",Orthodox,"Oct 14, 1998",http://ufcstats.com/fighter-details/0f4a536507f33576
 Erin Blanchfield,"5' 4""",125 lbs.,"66""",Orthodox,"May 04, 1999",http://ufcstats.com/fighter-details/669970f7feba8ecd
 Maximo Blanco,"5' 8""",145 lbs.,"71""",Orthodox,"Oct 16, 1983",http://ufcstats.com/fighter-details/4a1329cc8eb0928a
 David Blanco,"5' 7""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/ebf298f8ac7e232b
 Curtis Blaydes,"6' 4""",265 lbs.,"80""",Orthodox,"Feb 18, 1991",http://ufcstats.com/fighter-details/fa6796c55d6c5440
+Tereza Bleda,"5' 9""",125 lbs.,"71""",Orthodox,"Nov 30, 2001",http://ufcstats.com/fighter-details/59c438c81fbf3ece
 Arlene Blencowe,"5' 5""",145 lbs.,--,,"Apr 11, 1983",http://ufcstats.com/fighter-details/35d6337320a4ae48
 Byron Bloodworth,"5' 8""",135 lbs.,--,Orthodox,"Aug 16, 1983",http://ufcstats.com/fighter-details/ecdf14f4f8643d39
 Dashawn Boatwright,"6' 0""",205 lbs.,--,Orthodox,"Feb 29, 1988",http://ufcstats.com/fighter-details/046a85108610c0d2
@@ -324,24 +386,29 @@ Derek Bohi,"6' 4""",260 lbs.,--,,--,http://ufcstats.com/fighter-details/70a1c762
 Jerry Bohlander,"5' 11""",199 lbs.,--,Orthodox,"Feb 12, 1974",http://ufcstats.com/fighter-details/93892752c5fc23ca
 Mandy Bohm,"5' 7""",125 lbs.,"71""",Orthodox,"Jul 30, 1989",http://ufcstats.com/fighter-details/297a2b35444c245b
 Kotetsu Boku,"5' 9""",154 lbs.,--,Orthodox,"May 27, 1977",http://ufcstats.com/fighter-details/d227958e8a0c1466
+Gaston Bolanos,"5' 7""",135 lbs.,"69""",Orthodox,"Sep 14, 1992",http://ufcstats.com/fighter-details/96924b0019b3aff1
 Kyle Bolt,"6' 2""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/9d455d5cfe6a0e35
 Denys Bondar,"5' 6""",125 lbs.,"69""",Orthodox,"Jun 27, 1992",http://ufcstats.com/fighter-details/2526be54e6a0e62a
 Luc Bondole,"6' 2""",205 lbs.,--,,--,http://ufcstats.com/fighter-details/8691881b31c16b88
 Tony Bonello,"6' 2""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/702a72aa7a266d86
+Gabriel Bonfim,"6' 1""",170 lbs.,"72""",Orthodox,"Aug 20, 1997",http://ufcstats.com/fighter-details/01641ba5df0c69b0
+Ismael Bonfim,"5' 8""",155 lbs.,"71""",Orthodox,"Dec 28, 1995",http://ufcstats.com/fighter-details/eb393afdbe3293d5
 Jesse Bongfeldt,"6' 0""",185 lbs.,--,Orthodox,"Aug 28, 1980",http://ufcstats.com/fighter-details/934de214814b8ff4
 Marcos Bonilla,"5' 10""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/d311fbefff44a39b
 Stephan Bonnar,"6' 4""",205 lbs.,"79""",Orthodox,"Apr 04, 1977",http://ufcstats.com/fighter-details/c6a33ff198aaaeeb
 Rogerio Bontorin,"5' 5""",125 lbs.,"67""",Orthodox,"Apr 25, 1992",http://ufcstats.com/fighter-details/07a2bdaa0afdd831
 Ray Borg,"5' 4""",135 lbs.,"63""",Orthodox,"Aug 04, 1993",http://ufcstats.com/fighter-details/a4de54ea806fb525
 Igor Borisov,"6' 0""",235 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/0313bf497de9c470
+Kevin Borjas,"5' 5""",125 lbs.,"68""",Orthodox,"Dec 06, 1997",http://ufcstats.com/fighter-details/34b96d52db1d26e6
 Calen Born,"5' 8""",170 lbs.,"72""",Switch,"May 24, 1988",http://ufcstats.com/fighter-details/3c85e04b08a05751
-Caio Borralho,"5' 10""",205 lbs.,"75""",Southpaw,"Jan 16, 1993",http://ufcstats.com/fighter-details/4126a78111c0855a
+Caio Borralho,"6' 1""",185 lbs.,"75""",Southpaw,"Jan 16, 1993",http://ufcstats.com/fighter-details/4126a78111c0855a
+Zachary Borrego,"6' 2""",185 lbs.,"78""",Switch,"Jul 18, 1996",http://ufcstats.com/fighter-details/b8fdb2903a2582a8
 Viacheslav Borshchev,"5' 11""",155 lbs.,"69""",Orthodox,"Jan 08, 1992",http://ufcstats.com/fighter-details/19c591115a58982c
-Tanner Boser,"6' 2""",255 lbs.,"75""",Orthodox,"Aug 02, 1991",http://ufcstats.com/fighter-details/04c8b08b16a5b99e
+Tanner Boser,"6' 2""",205 lbs.,"75""",Orthodox,"Aug 02, 1991",http://ufcstats.com/fighter-details/04c8b08b16a5b99e
 Steve Bosse,"5' 11""",205 lbs.,"72""",Orthodox,"Jul 29, 1981",http://ufcstats.com/fighter-details/e023fa2e648ea0f1
 Marcus Bossett,"6' 1""",215 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/e8fb8e53bc2e29d6
 Chris Bostick,--,--,--,,--,http://ufcstats.com/fighter-details/239224bedeb2c7a4
-Poliana Botelho,"5' 8""",115 lbs.,"67""",Orthodox,"Dec 15, 1988",http://ufcstats.com/fighter-details/5c126c6aac3ef364
+Poliana Botelho,"5' 8""",125 lbs.,"67""",Orthodox,"Dec 15, 1988",http://ufcstats.com/fighter-details/5c126c6aac3ef364
 Francois Botha,"6' 2""",260 lbs.,--,Orthodox,"Sep 28, 1968",http://ufcstats.com/fighter-details/545d549d6bf87187
 Gregory Bouchelaghem,"6' 2""",183 lbs.,--,Switch,--,http://ufcstats.com/fighter-details/59851163aaf1aed8
 Roy Boughton,"6' 0""",205 lbs.,--,,--,http://ufcstats.com/fighter-details/2aaf0181432adf0b
@@ -355,19 +422,25 @@ Brian Bowles,"5' 7""",135 lbs.,"70""",Orthodox,"Jun 22, 1980",http://ufcstats.co
 Roger Bowling,"5' 9""",155 lbs.,"68""",Orthodox,"Dec 05, 1982",http://ufcstats.com/fighter-details/3b9f723e2720a238
 Blake Bowman,"6' 2""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/a95a0504fd73bd3e
 Ashe Bowman,"5' 9""",155 lbs.,--,,"Nov 17, 1976",http://ufcstats.com/fighter-details/8a0a35e7c74bebcc
+Anvar Boynazarov,"5' 9""",145 lbs.,--,Orthodox,"Jan 10, 1989",http://ufcstats.com/fighter-details/4a191f4ea2fce7fc
 ColleyBradford,"5' 7""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/1433786ac76cf777
 Kyle Bradley,"5' 9""",155 lbs.,"71""",Orthodox,"Aug 19, 1982",http://ufcstats.com/fighter-details/a6959da32f0e6b5d
 Paul Bradley,"5' 9""",170 lbs.,--,Orthodox,"Jun 13, 1983",http://ufcstats.com/fighter-details/c7011de4765d2497
 Sean Brady,"5' 10""",170 lbs.,"72""",Orthodox,"Nov 23, 1992",http://ufcstats.com/fighter-details/45f7cb591c3ab00b
 Ebenezer Fontes Braga,"6' 0""",199 lbs.,--,Orthodox,"Apr 14, 1969",http://ufcstats.com/fighter-details/dc950d59dc590aca
 Ramiz Brahimaj,"5' 10""",170 lbs.,"72""",Orthodox,"Nov 17, 1992",http://ufcstats.com/fighter-details/3d074044a33825e7
+Adam Bramhald,"5' 10""",135 lbs.,"70""",Orthodox,"Mar 24, 1994",http://ufcstats.com/fighter-details/3c99bd6cb5d835ef
 Joe Brammer,"5' 8""",155 lbs.,--,Orthodox,"Aug 23, 1983",http://ufcstats.com/fighter-details/013da757877044a2
 David Branch,"6' 1""",185 lbs.,"78""",Orthodox,"Sep 26, 1981",http://ufcstats.com/fighter-details/d2c55d1d2e67773b
+Billy Brand,"5' 6""",135 lbs.,"65""",Orthodox,"Jul 03, 1996",http://ufcstats.com/fighter-details/edae6db2b3453632
 Diego Brandao,"5' 7""",145 lbs.,"64""",Orthodox,"May 27, 1987",http://ufcstats.com/fighter-details/c2e3e67b5911bfb7
+Bruna Brasil,"5' 6""",115 lbs.,"65""",Orthodox,"Sep 07, 1993",http://ufcstats.com/fighter-details/7138a15258dabf20
 Michael Bravo,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/dc63542668295c23
 Martin Bravo,"5' 8""",145 lbs.,"71""",Southpaw,"Sep 21, 1993",http://ufcstats.com/fighter-details/9c44f290f5726d95
+Roman Bravo-Young,--,205 lbs.,--,,--,http://ufcstats.com/fighter-details/37ce890a4670b287
 Mike Breeden,"5' 10""",155 lbs.,"70""",Orthodox,"Apr 21, 1989",http://ufcstats.com/fighter-details/d80ee110748171ac
 Tom Breese,"6' 3""",185 lbs.,"73""",Southpaw,"Sep 26, 1991",http://ufcstats.com/fighter-details/1588b787bda7b540
+Elves Brener,"5' 10""",155 lbs.,"72""",Orthodox,"Sep 27, 1997",http://ufcstats.com/fighter-details/48a9a128784d53d1
 Chris Brennan,"5' 8""",170 lbs.,--,Orthodox,"Oct 12, 1971",http://ufcstats.com/fighter-details/b19fc66613dc75b9
 Charlie Brenneman,"5' 10""",155 lbs.,"70""",Orthodox,"Feb 09, 1981",http://ufcstats.com/fighter-details/98f6da59d765ec94
 Robert Breslin,"5' 11""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/e319d6697d41f3cf
@@ -379,6 +452,8 @@ Aaron Brink,"6' 3""",205 lbs.,--,Orthodox,"Nov 12, 1974",http://ufcstats.com/fig
 Henry Briones,"5' 8""",135 lbs.,"69""",Orthodox,"Oct 22, 1980",http://ufcstats.com/fighter-details/01fcef7e3d051722
 Marcelo Brito,"6' 1""",170 lbs.,--,Orthodox,"Nov 27, 1977",http://ufcstats.com/fighter-details/3a97fda0de6f1fa4
 Joanderson Brito,"5' 8""",145 lbs.,"72""",Orthodox,"Feb 11, 1995",http://ufcstats.com/fighter-details/791c8437b341fba5
+Kaik Brito,"5' 11""",170 lbs.,"72""",Orthodox,"Mar 26, 1997",http://ufcstats.com/fighter-details/b07f14fc0e53f8bd
+Icaro Brito,--,145 lbs.,--,,"Mar 09, 1999",http://ufcstats.com/fighter-details/06dd61c8d545c63f
 Antwain Britt,"6' 1""",205 lbs.,"77""",,"May 09, 1978",http://ufcstats.com/fighter-details/2833f50b20e96e52
 Drew Brokenshire,--,--,--,,--,http://ufcstats.com/fighter-details/aa571d75f80fde7d
 Mike Bronzoulis,"6' 0""",155 lbs.,--,,"Jan 05, 1979",http://ufcstats.com/fighter-details/df3c39573d01f55b
@@ -408,22 +483,24 @@ Fernando Bruno,"5' 6""",145 lbs.,--,,"Feb 24, 1982",http://ufcstats.com/fighter-
 Derek Brunson,"6' 1""",185 lbs.,"77""",Southpaw,"Jan 04, 1984",http://ufcstats.com/fighter-details/b1a3e0aca758b322
 Josh Bryant,"5' 10""",185 lbs.,--,Orthodox,"Apr 23, 1980",http://ufcstats.com/fighter-details/01f022fa494188e2
 Dennis Bryant,"6' 0""",205 lbs.,--,Orthodox,"Oct 18, 1985",http://ufcstats.com/fighter-details/3b17353b8002c7d0
+Robert Bryczek,"6' 0""",185 lbs.,"75""",Orthodox,"Jul 04, 1990",http://ufcstats.com/fighter-details/f96856f9d69fd7e4
 Lukasz Brzeski,"6' 4""",236 lbs.,"78""",Orthodox,"May 17, 1992",http://ufcstats.com/fighter-details/0c25d0a5e8cdbf19
 Justin Buchholz,"6' 0""",155 lbs.,"73""",Orthodox,"Aug 22, 1983",http://ufcstats.com/fighter-details/231926533134ec1f
 Zak Bucia,"5' 10""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/6bbb8dc6e128779e
 Courtney Buck,"5' 10""",135 lbs.,--,Orthodox,"Mar 19, 1982",http://ufcstats.com/fighter-details/3feed7d02711d8b7
-Joaquin Buckley,"5' 10""",185 lbs.,"76""",Southpaw,"Apr 27, 1994",http://ufcstats.com/fighter-details/b9437600497350f3
+Joaquin Buckley,"5' 10""",170 lbs.,"76""",Southpaw,"Apr 27, 1994",http://ufcstats.com/fighter-details/b9437600497350f3
 Martin Buday,"6' 4""",265 lbs.,"77""",Orthodox,"Nov 11, 1991",http://ufcstats.com/fighter-details/8eb046f83e82bf26
 Julia Budd,"5' 7""",145 lbs.,"67""",,"Jul 04, 1983",http://ufcstats.com/fighter-details/dcdc4503b9d49977
+Dylan Budka,"6' 0""",185 lbs.,"75""",Switch,"Jan 14, 2000",http://ufcstats.com/fighter-details/a817e238b2747404
 Mike Budnik,"5' 9""",145 lbs.,"68""",Orthodox,"Aug 08, 1974",http://ufcstats.com/fighter-details/b98209144b63ae26
 Francisco Bueno,"5' 9""",225 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/a72d260b436924c4
-Mayra Bueno Silva,"5' 6""",125 lbs.,"66""",Orthodox,"Aug 22, 1991",http://ufcstats.com/fighter-details/cc8c623cca88f54f
+Mayra Bueno Silva,"5' 6""",135 lbs.,"66""",Orthodox,"Aug 22, 1991",http://ufcstats.com/fighter-details/cc8c623cca88f54f
 Paul Buentello,"6' 2""",245 lbs.,"77""",Orthodox,"Jan 16, 1974",http://ufcstats.com/fighter-details/f0abbb6f3444dae7
 Modestas Bukauskas,"6' 3""",205 lbs.,"78""",Switch,"Feb 10, 1994",http://ufcstats.com/fighter-details/476fe566d2df676e
 Lee Kwan Bum,"6' 2""",286 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/c0342805a1948cbb
 Josh Bumgarner,"6' 1""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/9900ab86a4c458bd
 Shawn Bunch,"5' 5""",135 lbs.,--,,"Mar 19, 1983",http://ufcstats.com/fighter-details/6e9af164ab91a229
-Wuliji Buren,"5' 9""",135 lbs.,"69""",Orthodox,"Mar 01, 1989",http://ufcstats.com/fighter-details/2296125b6c362355
+Felipe Bunes,"5' 7""",125 lbs.,"69""",Orthodox,"Oct 29, 1989",http://ufcstats.com/fighter-details/53c10176e3bc7416
 Shane Burgos,"5' 11""",145 lbs.,"75""",Orthodox,"Mar 19, 1991",http://ufcstats.com/fighter-details/98d961097baaf308
 Joshua Burkman,"5' 10""",170 lbs.,"72""",Orthodox,"Apr 10, 1980",http://ufcstats.com/fighter-details/6da99156486ed6c2
 Justin Burlinson,"6' 1""",170 lbs.,"74""",Switch,"May 19, 1997",http://ufcstats.com/fighter-details/dadd80ef954e54ed
@@ -447,8 +524,9 @@ Todd Butler,"6' 1""",200 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details
 Goldman Butler,--,--,--,,--,http://ufcstats.com/fighter-details/e2d5072048b825b1
 Ian Butler,"5' 8""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/6b8fd98eb52363d1
 Raphael Butler,"6' 3""",261 lbs.,--,,"Jan 04, 1984",http://ufcstats.com/fighter-details/f941505e35fb1eae
+Jesse Butler,"5' 10""",135 lbs.,"73""",Orthodox,"May 24, 1992",http://ufcstats.com/fighter-details/a75a48bfe776b2c2
 JP Buys,"5' 5""",135 lbs.,"67""",Orthodox,"Apr 30, 1996",http://ufcstats.com/fighter-details/0b362247806341e5
-Dennis Buzukja,"5' 9""",145 lbs.,"71""",Switch,"Oct 01, 1997",http://ufcstats.com/fighter-details/c4d039123e62f6a9
+Dennis Buzukja,"5' 9""",145 lbs.,"70""",Switch,"Oct 01, 1997",http://ufcstats.com/fighter-details/c4d039123e62f6a9
 Charles Byrd,"5' 10""",185 lbs.,"73""",Orthodox,"Oct 11, 1983",http://ufcstats.com/fighter-details/76ee3d666c648f6b
 Steve Byrnes,"6' 0""",170 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/43612456979e5d5e
 Michael Byrnes,"5' 11""",155 lbs.,--,,"Jul 17, 1990",http://ufcstats.com/fighter-details/87f0b37f153cf497
@@ -459,11 +537,14 @@ Vince Cachero,"5' 6""",145 lbs.,"68""",Orthodox,"Nov 07, 1989",http://ufcstats.c
 Priscila Cachoeira,"5' 7""",125 lbs.,"65""",Orthodox,"Aug 19, 1988",http://ufcstats.com/fighter-details/b1e5bcaad32a3cac
 Travis Calanoc,"5' 8""",145 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/90d28fee0af74f2d
 Ricky Calatayud,"5' 9""",125 lbs.,--,,"Oct 10, 1982",http://ufcstats.com/fighter-details/800feaa25700a85f
+Carlos Calderon,"5' 11""",145 lbs.,"71""",Southpaw,"Feb 10, 1996",http://ufcstats.com/fighter-details/7d4d7583df7eebf9
 Darrion Caldwell,"5' 10""",135 lbs.,--,,"Dec 19, 1987",http://ufcstats.com/fighter-details/b7dc25ee40ee8334
+Nicolle Caliari,"5' 3""",125 lbs.,"62""",Orthodox,"Nov 04, 1996",http://ufcstats.com/fighter-details/fc0a4053eb8a3a59
 Taylor Callens,"5' 10""",155 lbs.,--,,"May 21, 1991",http://ufcstats.com/fighter-details/53d471e9bf5f2fc8
-Cynthia Calvillo,"5' 4""",125 lbs.,"64""",Orthodox,"Jul 13, 1987",http://ufcstats.com/fighter-details/98215d037be5bcb7
+Cynthia Calvillo,"5' 4""",115 lbs.,"64""",Orthodox,"Jul 13, 1987",http://ufcstats.com/fighter-details/98215d037be5bcb7
 Joe Camacho,"5' 9""",155 lbs.,--,Orthodox,"Mar 10, 1972",http://ufcstats.com/fighter-details/dfb965c9824425db
-Frank Camacho,"5' 10""",170 lbs.,"73""",Orthodox,"May 18, 1989",http://ufcstats.com/fighter-details/764342d39cdaa54a
+Frank Camacho,"5' 10""",155 lbs.,"73""",Orthodox,"May 18, 1989",http://ufcstats.com/fighter-details/764342d39cdaa54a
+Lucas Camacho,"6' 4""",265 lbs.,"80""",Orthodox,"Dec 15, 1992",http://ufcstats.com/fighter-details/71d25689f70e4036
 Fabricio Camoes,"5' 10""",155 lbs.,"71""",Orthodox,"Dec 23, 1978",http://ufcstats.com/fighter-details/7abe471b61725980
 Chris Camozzi,"6' 2""",185 lbs.,"75""",Orthodox,"Nov 20, 1986",http://ufcstats.com/fighter-details/6c2030e0a143a94b
 Brian Camozzi,"6' 2""",170 lbs.,"78""",Orthodox,"Jun 24, 1991",http://ufcstats.com/fighter-details/1999ffb5cebc314f
@@ -471,6 +552,7 @@ Ricky Camp,"5' 7""",135 lbs.,--,,--,http://ufcstats.com/fighter-details/4a99978a
 Mike Campbell,"5' 9""",155 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/f5585e675af7afd4
 Thomas Campbell,--,--,--,,--,http://ufcstats.com/fighter-details/d060014a5a039829
 Shane Campbell,"6' 0""",155 lbs.,"71""",Orthodox,"Jan 21, 1987",http://ufcstats.com/fighter-details/784285b7ae7dd85f
+Charlie Campbell,"6' 0""",155 lbs.,"72""",Orthodox,"Jul 03, 1995",http://ufcstats.com/fighter-details/b39f7a6c2be17ee8
 John Campetella,"5' 9""",235 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/31bbd46d57dfbcb7
 Wagner Campos,"5' 6""",145 lbs.,--,Southpaw,"Jul 31, 1981",http://ufcstats.com/fighter-details/db6d5f691aea3fd3
 Derek Campos,"5' 9""",155 lbs.,--,,"Apr 01, 1988",http://ufcstats.com/fighter-details/aa8dc72b3a1f761c
@@ -508,6 +590,7 @@ Roan Carneiro,"5' 11""",170 lbs.,"76""",Orthodox,"Jun 02, 1978",http://ufcstats.
 Ariane Carnelossi,"5' 2""",115 lbs.,"61""",Orthodox,"Nov 17, 1992",http://ufcstats.com/fighter-details/c0d5c0c95c59050b
 Luana Carolina,"5' 6""",125 lbs.,"69""",Orthodox,"Jun 11, 1993",http://ufcstats.com/fighter-details/528b071cf3da7c56
 Tim Caron,"6' 1""",185 lbs.,--,Orthodox,"Jul 24, 1987",http://ufcstats.com/fighter-details/b80ea4880f25c187
+Clayton Carpenter,"5' 6""",125 lbs.,"66""",Orthodox,"Jun 09, 1996",http://ufcstats.com/fighter-details/b62d5280966b2460
 Gabriel Carrasco,"5' 6""",135 lbs.,--,,--,http://ufcstats.com/fighter-details/89ed44801968b8e3
 Cody Carrillo,"5' 10""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/9346efb4bbaedd08
 Cain Carrizosa,"5' 8""",155 lbs.,--,Orthodox,"Jul 22, 1986",http://ufcstats.com/fighter-details/064b7dc68d786254
@@ -515,6 +598,7 @@ Roger Carroll,"5' 10""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/572a
 Jonny Carson,"5' 10""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/0d49ddc07bd8c747
 Scott Carson,"6' 2""",215 lbs.,--,,--,http://ufcstats.com/fighter-details/1e3302f9ab6f549a
 Shonie Carter,"5' 10""",170 lbs.,--,Southpaw,"May 03, 1972",http://ufcstats.com/fighter-details/7b6e40a73b567072
+Jack Cartwright,"5' 9""",135 lbs.,"68""",Orthodox,"May 26, 1994",http://ufcstats.com/fighter-details/1f592bfefb0d62a3
 Bruno Carvalho,"5' 8""",154 lbs.,--,,"Jun 07, 1982",http://ufcstats.com/fighter-details/456c02115efc4a01
 Antonio Carvalho,"5' 9""",145 lbs.,"70""",Orthodox,"May 30, 1979",http://ufcstats.com/fighter-details/fef3d17e27e916e7
 Rafael Carvalho,"6' 3""",185 lbs.,--,,"Jul 27, 1986",http://ufcstats.com/fighter-details/620d8710e89cfeae
@@ -537,19 +621,27 @@ Nick Catone,"6' 0""",185 lbs.,"72""",Southpaw,"Sep 01, 1981",http://ufcstats.com
 Luke Caudillo,"5' 7""",155 lbs.,--,Orthodox,"Nov 30, 1980",http://ufcstats.com/fighter-details/68d76fd9ecf7431d
 Gesias Cavalcante,"5' 8""",155 lbs.,"71""",Orthodox,"Jul 06, 1983",http://ufcstats.com/fighter-details/2a74bbba57058f12
 Rafael Cavalcante,"6' 1""",205 lbs.,"74""",Orthodox,"Apr 14, 1980",http://ufcstats.com/fighter-details/5c1ca0c72b599a3c
+Jacqueline Cavalcanti,"5' 8""",135 lbs.,"70""",Orthodox,"Aug 29, 1997",http://ufcstats.com/fighter-details/e3964ece586e0635
+Igor Cavalcanti,"5' 11""",170 lbs.,"79""",Orthodox,"Oct 10, 1997",http://ufcstats.com/fighter-details/9c3de7f8966326de
 Magnus Cedenblad,"6' 5""",185 lbs.,"79""",Orthodox,"Apr 10, 1982",http://ufcstats.com/fighter-details/0e21976afc92e4d1
 Yosdenis Cedeno,"5' 8""",155 lbs.,"69""",Orthodox,"Feb 12, 1985",http://ufcstats.com/fighter-details/3e61082025db8137
 Henry Cejudo,"5' 4""",135 lbs.,"64""",Orthodox,"Feb 09, 1987",http://ufcstats.com/fighter-details/056c493bbd76a918
 Adam Cella,"6' 2""",170 lbs.,--,,"Jun 26, 1985",http://ufcstats.com/fighter-details/b27b8881d7444114
-Donald Cerrone,"6' 1""",170 lbs.,"73""",Orthodox,"Mar 29, 1983",http://ufcstats.com/fighter-details/1d00756835ca67c9
+Vinicius Cenci,"6' 1""",155 lbs.,"74""",Orthodox,"Nov 24, 1995",http://ufcstats.com/fighter-details/f21a152aaa3e95c6
+Katlyn Cerminara,"5' 9""",125 lbs.,"68""",Orthodox,"Dec 28, 1988",http://ufcstats.com/fighter-details/e872e9a9a902c045
+Rafael Cerqueira,"6' 3""",205 lbs.,"76""",Southpaw,"Mar 15, 1990",http://ufcstats.com/fighter-details/09a4447655fd4b7b
+Donald Cerrone,"6' 1""",155 lbs.,"73""",Orthodox,"Mar 29, 1983",http://ufcstats.com/fighter-details/1d00756835ca67c9
 Jared Chaffee,"5' 10""",155 lbs.,--,,"Dec 15, 1984",http://ufcstats.com/fighter-details/fdf59144e535bc38
 Luan Chagas,"6' 0""",170 lbs.,"75""",Orthodox,"Jun 17, 1993",http://ufcstats.com/fighter-details/9ccf8371fd80d45d
+Edgar Chairez,"5' 7""",125 lbs.,"71""",Orthodox,"Jan 27, 1996",http://ufcstats.com/fighter-details/5ef94841c4bc3f86
 Ansar Chalangov,"5' 9""",170 lbs.,--,Orthodox,"Oct 30, 1979",http://ufcstats.com/fighter-details/7342fcc41a4817fa
 Alex Chambers,"5' 3""",115 lbs.,"63""",Southpaw,"Oct 25, 1978",http://ufcstats.com/fighter-details/26b63bc5c0c1f65d
 Michael Chandler,"5' 8""",155 lbs.,"71""",Orthodox,"Apr 24, 1986",http://ufcstats.com/fighter-details/4b93a88f3b1de35b
+Chelsea Chandler,"5' 8""",135 lbs.,"68""",Southpaw,"Nov 23, 1990",http://ufcstats.com/fighter-details/af9efbfd63d39734
 Donnie Chappell,"5' 11""",178 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/8788beb528894f33
 Joe Charles,"6' 1""",260 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/19ffeb5e3fffd6d5
 Dan Charles,"6' 2""",228 lbs.,--,,"Sep 24, 1985",http://ufcstats.com/fighter-details/32a4f1235f0dad73
+Morgan Charriere,"5' 8""",145 lbs.,"69""",Orthodox,"Oct 26, 1995",http://ufcstats.com/fighter-details/5b03b61f9d90125e
 Ernest Chavez,"5' 8""",145 lbs.,"70""",Orthodox,"Jun 27, 1983",http://ufcstats.com/fighter-details/b406da701c479076
 Emilio Chavez,"5' 9""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/84e8920e59ff14a7
 Danny Chavez,"5' 8""",145 lbs.,"67""",Orthodox,"Mar 14, 1987",http://ufcstats.com/fighter-details/0de720c0f1d4ab9c
@@ -558,20 +650,22 @@ Albert Cheng,"5' 11""",170 lbs.,--,Orthodox,"Feb 07, 1985",http://ufcstats.com/f
 Fabio Cherant,"6' 1""",205 lbs.,"74""",Southpaw,"Nov 25, 1994",http://ufcstats.com/fighter-details/78a68f1dade6aaf7
 Ion Cherdivara,--,205 lbs.,--,,--,http://ufcstats.com/fighter-details/c713a845360d604b
 Mark Cherico,"5' 7""",145 lbs.,"69""",Orthodox,"May 12, 1986",http://ufcstats.com/fighter-details/79a193111e3bc99b
-Macy Chiasson,"5' 11""",145 lbs.,"72""",Orthodox,"Jul 27, 1991",http://ufcstats.com/fighter-details/9cdd2da1a9104a0b
+Macy Chiasson,"5' 11""",135 lbs.,"72""",Orthodox,"Jul 27, 1991",http://ufcstats.com/fighter-details/9cdd2da1a9104a0b
 Michael Chiesa,"6' 1""",170 lbs.,"75""",Southpaw,"Dec 07, 1987",http://ufcstats.com/fighter-details/c58f51dedb310998
 Giga Chikadze,"6' 0""",145 lbs.,"74""",Orthodox,"Aug 25, 1988",http://ufcstats.com/fighter-details/9560ff14eb3129f7
-Khamzat Chimaev,"6' 2""",170 lbs.,"75""",Orthodox,"May 01, 1994",http://ufcstats.com/fighter-details/767755fd74662dbf
-Sako Chivitchian,"5' 11""",155 lbs.,--,,"Mar 11, 1984",http://ufcstats.com/fighter-details/9f7787e56a6bc0f4
+Khamzat Chimaev,"6' 2""",185 lbs.,"75""",Orthodox,"May 01, 1994",http://ufcstats.com/fighter-details/767755fd74662dbf
+Sako Chivitchian,"5' 11""",155 lbs.,--,Orthodox,"Mar 11, 1984",http://ufcstats.com/fighter-details/9f7787e56a6bc0f4
 Mu Bae Choi,"6' 2""",230 lbs.,--,Orthodox,"Jun 27, 1970",http://ufcstats.com/fighter-details/371a1c91b24dec2b
 Hong Man Choi,"7' 2""",330 lbs.,--,Orthodox,"Oct 30, 1980",http://ufcstats.com/fighter-details/2c104b7e59a72629
 Dooho Choi,"5' 10""",145 lbs.,"70""",Orthodox,"Apr 10, 1991",http://ufcstats.com/fighter-details/e93b04e308913c2e
 SeungWoo Choi,"6' 0""",145 lbs.,"74""",Orthodox,"Nov 03, 1992",http://ufcstats.com/fighter-details/a68575214ecad140
+SeungGuk Choi,"5' 6""",125 lbs.,"64""",Orthodox,"Dec 26, 1996",http://ufcstats.com/fighter-details/adccbc19b22e19af
+DongHun Choi,"5' 5""",125 lbs.,"66""",Switch,"Jan 02, 1999",http://ufcstats.com/fighter-details/3be16d817b36098b
 John Cholish,"5' 11""",155 lbs.,"74""",Orthodox,"Dec 17, 1983",http://ufcstats.com/fighter-details/03c9994c5b8958ec
 Ryo Chonan,"5' 9""",170 lbs.,"70""",Orthodox,"Oct 08, 1976",http://ufcstats.com/fighter-details/55a7b2d4e54ffac9
-Katlyn Chookagian,"5' 9""",125 lbs.,"68""",Orthodox,"Dec 28, 1988",http://ufcstats.com/fighter-details/e872e9a9a902c045
 Will Chope,"6' 4""",145 lbs.,--,Switch,"Sep 08, 1990",http://ufcstats.com/fighter-details/db5dc7cb80d7d418
 Joachim Christensen,"6' 3""",205 lbs.,"76""",Orthodox,"Nov 07, 1978",http://ufcstats.com/fighter-details/2d447cc91bdaa545
+Kevin Christian,"6' 7""",205 lbs.,"80""",Orthodox,"Jan 21, 1995",http://ufcstats.com/fighter-details/7e9b36a9847db116
 Dan Christison,"6' 8""",265 lbs.,--,Orthodox,"Apr 26, 1972",http://ufcstats.com/fighter-details/b369533a577fa97c
 Anthony Christodoulou,"5' 9""",155 lbs.,--,Orthodox,"Jul 30, 1987",http://ufcstats.com/fighter-details/4f11e9ce318ffbcb
 Murad Chunkaiev,"5' 11""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/d4a12dfa4067742f
@@ -581,7 +675,7 @@ Mike Ciesnolevicz,"6' 0""",235 lbs.,--,Orthodox,"Oct 28, 1979",http://ufcstats.c
 Hannah Cifers,"5' 1""",115 lbs.,"62""",Orthodox,"Jun 26, 1992",http://ufcstats.com/fighter-details/2244d9a2b64b8c3b
 Branko Cikatic,"6' 1""",215 lbs.,--,Orthodox,"Oct 03, 1954",http://ufcstats.com/fighter-details/4e5bbc4566049cbf
 Nikolajus Cilkinas,--,--,--,Orthodox,--,http://ufcstats.com/fighter-details/3f3550bf126a5721
-Misha Cirkunov,"6' 3""",185 lbs.,"77""",Orthodox,"Feb 27, 1987",http://ufcstats.com/fighter-details/67f272324a030d00
+Misha Cirkunov,"6' 3""",205 lbs.,"77""",Orthodox,"Feb 27, 1987",http://ufcstats.com/fighter-details/67f272324a030d00
 Johnny Cisneros,"5' 11""",170 lbs.,--,,"Feb 05, 1980",http://ufcstats.com/fighter-details/42611508ba8c3298
 Laverne Clark,"5' 11""",170 lbs.,--,Orthodox,"Dec 02, 1973",http://ufcstats.com/fighter-details/1c2f2571b18791b6
 Logan Clark,"6' 2""",185 lbs.,--,Orthodox,"Feb 16, 1985",http://ufcstats.com/fighter-details/6776260cb0aef647
@@ -590,11 +684,13 @@ Dominic Clark,"5' 10""",155 lbs.,--,,"Aug 01, 1985",http://ufcstats.com/fighter-
 Heather Clark,"5' 6""",115 lbs.,"64""",Orthodox,"Sep 19, 1980",http://ufcstats.com/fighter-details/dd4c16777fb2ccf9
 Devin Clark,"6' 0""",205 lbs.,"75""",Orthodox,"Apr 12, 1990",http://ufcstats.com/fighter-details/cc7040fe76f0ef91
 Jessica-Rose Clark,"5' 5""",135 lbs.,"64""",Orthodox,"Nov 28, 1987",http://ufcstats.com/fighter-details/6c8072b61c276e67
+Shannon Clark,"5' 5""",125 lbs.,"64""",Orthodox,"Jul 07, 1992",http://ufcstats.com/fighter-details/7ae36b3791e0969a
 John Clarke,--,170 lbs.,--,,"Aug 15, 1977",http://ufcstats.com/fighter-details/a77c71a574132188
 Mitch Clarke,"5' 10""",155 lbs.,"73""",Orthodox,"Nov 24, 1985",http://ufcstats.com/fighter-details/c76ec2bc3a57666a
 Rich Clementi,"5' 9""",155 lbs.,"72""",Southpaw,"Mar 31, 1976",http://ufcstats.com/fighter-details/7d21de9c6d7c98b2
 Chris Clements,"5' 10""",170 lbs.,"70""",Orthodox,"Feb 09, 1976",http://ufcstats.com/fighter-details/e5ecaf884b6da2bc
 RJ Clifford,--,160 lbs.,--,,--,http://ufcstats.com/fighter-details/8e32bfcff3ec1717
+Mark Climaco,"5' 4""",125 lbs.,"65""",Southpaw,"Nov 06, 1997",http://ufcstats.com/fighter-details/60098849c703e389
 Josh Clopton,"5' 6""",145 lbs.,--,Orthodox,"Jul 11, 1981",http://ufcstats.com/fighter-details/48e96d9cea6d4ab0
 Brian Cobb,"5' 11""",155 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/3138fab619faf4d1
 Darryl Cobb,"5' 9""",185 lbs.,--,,"Aug 04, 1980",http://ufcstats.com/fighter-details/dc6d8256ee3dfba5
@@ -604,22 +700,24 @@ Marloes Coenen,"5' 9""",145 lbs.,"67""",,"Mar 31, 1981",http://ufcstats.com/figh
 Marc Cofer,--,185 lbs.,--,,"Mar 03, 1972",http://ufcstats.com/fighter-details/e90d9d0681270953
 John Cofer,"5' 9""",155 lbs.,--,Southpaw,"Apr 29, 1984",http://ufcstats.com/fighter-details/8b260672a21d1fd6
 Chris Coggins,--,--,--,,--,http://ufcstats.com/fighter-details/a0c29b13f7a5df32
-Felipe Colares,"5' 8""",135 lbs.,"69""",Orthodox,"Mar 31, 1994",http://ufcstats.com/fighter-details/dbac0a413af64bbe
+Felipe Colares,"5' 8""",145 lbs.,"69""",Orthodox,"Mar 31, 1994",http://ufcstats.com/fighter-details/dbac0a413af64bbe
 Wayne Cole,"6' 1""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/2eab7a6c8b0ed8cc
 Devin Cole,"6' 4""",240 lbs.,--,Orthodox,"Oct 01, 1976",http://ufcstats.com/fighter-details/1174782eacde9b0c
 Coltin Cole,--,185 lbs.,--,,"Apr 24, 1989",http://ufcstats.com/fighter-details/cecd72feb0d640e3
 Ivan Cole,"5' 9""",135 lbs.,--,,"Nov 30, 1990",http://ufcstats.com/fighter-details/987b80f57190d6d0
+Chandler Cole,"5' 10""",264 lbs.,"72""",Orthodox,"Jan 09, 1995",http://ufcstats.com/fighter-details/5d8a9c95af50280a
 Mark Coleman,"6' 1""",205 lbs.,"75""",Orthodox,"Dec 20, 1964",http://ufcstats.com/fighter-details/21b8a0f5c231096f
 Cortez Coleman,"6' 1""",185 lbs.,--,,"Jan 28, 1982",http://ufcstats.com/fighter-details/ffb20ae0db47ebe6
 Clay Collard,"5' 11""",145 lbs.,"73""",Orthodox,"Mar 10, 1993",http://ufcstats.com/fighter-details/cc900c6a71ed23f3
 Jamie Colleen,"5' 3""",115 lbs.,"65""",Orthodox,"Nov 02, 1985",http://ufcstats.com/fighter-details/6b64db453edf4c50
 Jake Collier,"6' 3""",230 lbs.,"78""",Orthodox,"Oct 25, 1988",http://ufcstats.com/fighter-details/92fa1401b7927da3
 Christian Colombo,"6' 5""",265 lbs.,--,Orthodox,"Jul 01, 1980",http://ufcstats.com/fighter-details/9123c54d0a2b72dd
+Willian Colorado,"5' 10""",135 lbs.,"72""",,"Jun 21, 1986",http://ufcstats.com/fighter-details/dfc7f0a2d91ad337
 Wes Combs,"6' 2""",205 lbs.,--,Orthodox,"Jun 18, 1973",http://ufcstats.com/fighter-details/a85998eb79650b2c
+Rose Conceicao,"4' 7""",115 lbs.,"65""",Orthodox,"May 13, 1997",http://ufcstats.com/fighter-details/a76c07e8e4c76e9a
 Carlos Condit,"6' 2""",170 lbs.,"75""",Orthodox,"Apr 26, 1984",http://ufcstats.com/fighter-details/f9f07bb5a43535ed
 Chris Condo,"6' 0""",335 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/41e77dc504a192c6
-Montserrat Conejo,"5' 0""",115 lbs.,"61""",Southpaw,"Feb 03, 1993",http://ufcstats.com/fighter-details/1235b31de15d0c6e
-Tristan Connelly,"5' 10""",170 lbs.,"68""",Orthodox,"Dec 12, 1985",http://ufcstats.com/fighter-details/2ebfbe72ed703925
+Tristan Connelly,"5' 10""",145 lbs.,"68""",Orthodox,"Dec 12, 1985",http://ufcstats.com/fighter-details/2ebfbe72ed703925
 Marcos Conrado Jr.,"6' 2""",220 lbs.,--,Orthodox,"Mar 14, 1982",http://ufcstats.com/fighter-details/d450769115a193c2
 Jeremiah Constant,"6' 1""",240 lbs.,--,Orthodox,"Jul 19, 1974",http://ufcstats.com/fighter-details/18f5669a92e99d92
 Jonathan Contrestano,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/06d4eb8123087123
@@ -639,20 +737,24 @@ Michael Cora,"6' 1""",170 lbs.,"77""",Southpaw,"Aug 24, 1989",http://ufcstats.co
 Akira Corassani,"5' 8""",145 lbs.,"68""",Orthodox,"Aug 27, 1982",http://ufcstats.com/fighter-details/3f52ce18fb98008f
 Muhsin Corbbrey,"5' 10""",155 lbs.,--,Orthodox,"May 18, 1978",http://ufcstats.com/fighter-details/1f9344211ca7fd60
 Daniel Cormier,"5' 11""",235 lbs.,"72""",Orthodox,"Mar 20, 1979",http://ufcstats.com/fighter-details/d967f0128c323de6
+Nora Cornolle,"5' 7""",135 lbs.,"67""",Orthodox,"Dec 06, 1989",http://ufcstats.com/fighter-details/f2b3f4ef3f780168
 Clint Coronel,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/fe67cd6423f7a8ad
 Henry Corrales,"5' 9""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/7cb0946d51b8cde7
 Bethe Correia,"5' 5""",135 lbs.,"64""",Orthodox,"Jun 22, 1983",http://ufcstats.com/fighter-details/673ea7dcc786b1b3
 Wesley Correira,"6' 3""",260 lbs.,--,Orthodox,"Nov 11, 1978",http://ufcstats.com/fighter-details/4e9fb05d7e5e61b8
-Tracy Cortez,"5' 5""",135 lbs.,"65""",Orthodox,"Dec 10, 1993",http://ufcstats.com/fighter-details/68d4a891e5cf2029
-Reyes Cortez,"5' 7""",135 lbs.,"68""",Orthodox,"Jul 31, 1992",http://ufcstats.com/fighter-details/1a7d44196949577c
+Waldo Cortes-Acosta,"6' 4""",260 lbs.,"78""",Orthodox,"Oct 03, 1991",http://ufcstats.com/fighter-details/fc08099550072fe4
+Tracy Cortez,"5' 5""",125 lbs.,"65""",Orthodox,"Dec 10, 1993",http://ufcstats.com/fighter-details/68d4a891e5cf2029
+Reyes Cortez Jr.,"5' 7""",135 lbs.,"68""",Orthodox,"Jul 31, 1992",http://ufcstats.com/fighter-details/1a7d44196949577c
 Chad Corvin,"6' 5""",255 lbs.,--,,--,http://ufcstats.com/fighter-details/1267b631db78665a
 Louis Cosce,"5' 9""",170 lbs.,"71""",Orthodox,"Aug 27, 1995",http://ufcstats.com/fighter-details/afe8d5b39ff7fca2
 Orion Cosce,"5' 11""",170 lbs.,"71""",Switch,"Jul 15, 1994",http://ufcstats.com/fighter-details/2c010b26a3306969
 Miguel Cosio,"6' 4""",205 lbs.,--,,--,http://ufcstats.com/fighter-details/d150c6fbdb7687f4
 Jadson Costa,"5' 7""",155 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/222d6b547de2e035
 Guilherme Costa,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/28877eddb1c0b967
-Paulo Costa,"6' 1""",205 lbs.,"72""",Orthodox,"Apr 21, 1991",http://ufcstats.com/fighter-details/2e5c2aa8e4ab9d82
+Paulo Costa,"6' 1""",185 lbs.,"72""",Orthodox,"Apr 21, 1991",http://ufcstats.com/fighter-details/2e5c2aa8e4ab9d82
 Randy Costa,"5' 9""",135 lbs.,"73""",Switch,"Jul 06, 1994",http://ufcstats.com/fighter-details/325ad0dd9126d3df
+Alessandro Costa,"5' 4""",125 lbs.,"67""",Orthodox,"Jan 28, 1996",http://ufcstats.com/fighter-details/3fa97913cfd205d3
+Melquizael Costa,"5' 10""",145 lbs.,"71""",Southpaw,"Sep 14, 1996",http://ufcstats.com/fighter-details/20bccc9bb4ceb23e
 Oscar Cota,"6' 0""",230 lbs.,"72""",Orthodox,"Oct 15, 1984",http://ufcstats.com/fighter-details/f584a6e0b5b74604
 Patrick Cote,"5' 11""",170 lbs.,"75""",Orthodox,"Feb 29, 1980",http://ufcstats.com/fighter-details/9fa3bd637edd9aa2
 JC Cottrell,"5' 9""",155 lbs.,--,Orthodox,"Nov 04, 1989",http://ufcstats.com/fighter-details/3ec1e4ba98c9c85a
@@ -664,17 +766,20 @@ Kim Couture,"5' 8""",135 lbs.,--,Orthodox,"Dec 18, 1975",http://ufcstats.com/fig
 Ryan Couture,"5' 10""",155 lbs.,"73""",Orthodox,"Aug 27, 1982",http://ufcstats.com/fighter-details/46fd223e3ced39b3
 Nikk Covert,"5' 8""",185 lbs.,--,,"Aug 04, 1969",http://ufcstats.com/fighter-details/400c7b43c86d27d3
 Colby Covington,"5' 11""",170 lbs.,"72""",Orthodox,"Feb 22, 1988",http://ufcstats.com/fighter-details/dc9572dd6ec74859
+Hailey Cowan,"5' 8""",135 lbs.,"67""",Southpaw,"Feb 12, 1992",http://ufcstats.com/fighter-details/3c26c420584d912d
 Jeff Cox,"5' 10""",155 lbs.,--,Orthodox,"Aug 02, 1968",http://ufcstats.com/fighter-details/c9bbf1a0285a8076
 Nathan Coy,"5' 10""",170 lbs.,"69""",Southpaw,"Jul 24, 1978",http://ufcstats.com/fighter-details/15ec018d144710db
 Andrew Craig,"6' 1""",170 lbs.,"76""",Orthodox,"Jan 15, 1986",http://ufcstats.com/fighter-details/8a70ceb3edbe757b
-Paul Craig,"6' 3""",205 lbs.,"76""",Orthodox,"Nov 27, 1987",http://ufcstats.com/fighter-details/eabf206b162b3b83
+Paul Craig,"6' 3""",185 lbs.,"76""",Orthodox,"Nov 27, 1987",http://ufcstats.com/fighter-details/eabf206b162b3b83
 Dan Cramer,"6' 2""",170 lbs.,--,Orthodox,"Oct 31, 1985",http://ufcstats.com/fighter-details/480b702debcb5433
 Alberto Crane,"5' 5""",155 lbs.,--,Orthodox,"Jul 14, 1976",http://ufcstats.com/fighter-details/25433871e4eee0f4
 Tim Credeur,"6' 3""",185 lbs.,"75""",Orthodox,"Jul 09, 1977",http://ufcstats.com/fighter-details/89b8d1bf1ff09d1d
 Paul Creighton,"5' 6""",155 lbs.,--,Southpaw,"Jun 04, 1970",http://ufcstats.com/fighter-details/ed73c85164a5f5a4
+Helena Crevar,--,--,--,,--,http://ufcstats.com/fighter-details/a8c3ce469cb8b130
 Alexander Crispim,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/15dedd05f8bcb475
 Alex Crispin,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/8944a0f9b2f0ce6d
-Kevin Croom,"5' 11""",155 lbs.,"73""",Orthodox,"Jul 15, 1987",http://ufcstats.com/fighter-details/35b3772629e27a49
+Kevin Croom,"5' 11""",135 lbs.,"73""",Orthodox,"Jul 15, 1987",http://ufcstats.com/fighter-details/35b3772629e27a49
+Kiefer Crosbie,"5' 11""",170 lbs.,"70""",Switch,"Apr 05, 1990",http://ufcstats.com/fighter-details/4729c93ba705a3bf
 Ken Cross,"6' 0""",155 lbs.,"72""",Southpaw,"Oct 04, 1994",http://ufcstats.com/fighter-details/923767209632e08a
 Jeff Crotty,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/98601a40e9d96047
 Allen Crowder,"6' 3""",245 lbs.,"76""",Orthodox,"Nov 08, 1989",http://ufcstats.com/fighter-details/a9d6e047ce48ab63
@@ -684,29 +789,33 @@ Jimmy Crute,"6' 2""",205 lbs.,"74""",Orthodox,"Mar 04, 1996",http://ufcstats.com
 Marcio Cruz,"6' 4""",232 lbs.,--,Orthodox,"Apr 24, 1978",http://ufcstats.com/fighter-details/6aa1cbc1466e9a0b
 Dominick Cruz,"5' 8""",135 lbs.,"68""",Orthodox,"Mar 09, 1985",http://ufcstats.com/fighter-details/10f3ba6cd2f44a97
 Aalon Cruz,"6' 0""",145 lbs.,"78""",Switch,"Sep 20, 1989",http://ufcstats.com/fighter-details/003d82fa384ca1d0
+Timmy Cuamba,"5' 9""",145 lbs.,"71""",Orthodox,"Feb 08, 1999",http://ufcstats.com/fighter-details/0e46690e55a8df75
 Jay Cucciniello,"5' 7""",155 lbs.,--,Orthodox,"Jul 23, 1986",http://ufcstats.com/fighter-details/683ea28a198936fe
+Emilio Cuellar,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/3aeb69b4a13ff0e8
 Josh Culibao,"5' 10""",145 lbs.,"73""",Orthodox,"May 24, 1994",http://ufcstats.com/fighter-details/6751eacd16bd59bc
 Chris Culley,--,145 lbs.,--,,"Mar 25, 1986",http://ufcstats.com/fighter-details/e59b13321562eed3
 Abel Cullum,"5' 7""",139 lbs.,--,Orthodox,"Apr 21, 1987",http://ufcstats.com/fighter-details/2f8f3c69522db931
-Zak Cummings,"6' 0""",185 lbs.,"75""",Southpaw,"Aug 02, 1984",http://ufcstats.com/fighter-details/4ba8d454f762005d
+Zak Cummings,"6' 0""",205 lbs.,"75""",Southpaw,"Aug 02, 1984",http://ufcstats.com/fighter-details/4ba8d454f762005d
 Everett Cummings,--,205 lbs.,--,,--,http://ufcstats.com/fighter-details/05e4be525cb3578c
 Patrick Cummins,"6' 2""",205 lbs.,"76""",Orthodox,"Nov 16, 1980",http://ufcstats.com/fighter-details/e51e5cb722bd47a8
 Luke Cummo,"6' 0""",170 lbs.,"74""",Orthodox,"Apr 27, 1980",http://ufcstats.com/fighter-details/93ce4ac89e3d7652
-Hugo Cunha,"6' 4""",250 lbs.,--,,"Feb 04, 1993",http://ufcstats.com/fighter-details/46a17755f80f63e8
+Hugo Cunha,"6' 3""",263 lbs.,"79""",Orthodox,"Feb 04, 1993",http://ufcstats.com/fighter-details/46a17755f80f63e8
 Alton Cunningham,"6' 2""",205 lbs.,"77""",Orthodox,"Jun 24, 1993",http://ufcstats.com/fighter-details/305bde44ff664788
+AJ Cunningham,"5' 10""",145 lbs.,"71""",Orthodox,"Sep 07, 1994",http://ufcstats.com/fighter-details/d1053e55f00e53fe
 Santo Curatolo,"5' 3""",125 lbs.,"62""",Southpaw,"Jan 18, 1995",http://ufcstats.com/fighter-details/b8b765e320a8db39
 Larry Cureton,"6' 2""",240 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/46f11d15c0134fe3
 Jeff Curran,"5' 6""",135 lbs.,"69""",Orthodox,"Sep 02, 1977",http://ufcstats.com/fighter-details/a8ea84cbe1655f0a
 Kailin Curran,"5' 4""",115 lbs.,"65""",Orthodox,"Apr 11, 1991",http://ufcstats.com/fighter-details/05b43e0ead3df345
 Pat Curran,"5' 9""",145 lbs.,--,,"Aug 31, 1987",http://ufcstats.com/fighter-details/d8291d0dd63da29c
+Will Currie,"6' 3""",185 lbs.,"76""",Switch,"Nov 12, 1998",http://ufcstats.com/fighter-details/b8ff02d5703eca3a
 Chris Curtis,"5' 10""",185 lbs.,"75""",Orthodox,"Jul 15, 1987",http://ufcstats.com/fighter-details/5442f1bc4b47eaf3
 Ion Cutelaba,"6' 1""",205 lbs.,"75""",Southpaw,"Dec 14, 1993",http://ufcstats.com/fighter-details/cd13728ae1151f46
 Gleidson Cutis,"5' 9""",155 lbs.,--,Orthodox,"Feb 07, 1989",http://ufcstats.com/fighter-details/44a94bbde42246e4
 Sarah D'alelio,"5' 7""",145 lbs.,--,,"Dec 13, 1980",http://ufcstats.com/fighter-details/ac45450f75d14f16
 Marcos da Matta,"5' 4""",145 lbs.,--,,"Mar 18, 1973",http://ufcstats.com/fighter-details/3b6d84343579fd33
 Henrique da Silva,"6' 3""",205 lbs.,"76""",Orthodox,"Sep 01, 1989",http://ufcstats.com/fighter-details/b0bd0c5425668b8f
+Ariane da Silva,"5' 6""",125 lbs.,"67""",Orthodox,"Jan 26, 1994",http://ufcstats.com/fighter-details/6551c64fbcd1a467
 Alex Da Silva,"5' 8""",155 lbs.,"73""",Orthodox,"Feb 04, 1996",http://ufcstats.com/fighter-details/c3ded6f7155f9ea4
-Daniel Da Silva,"5' 6""",125 lbs.,"70""",Switch,"Jun 05, 1996",http://ufcstats.com/fighter-details/31bb0772f21cabd8
 Henrique Da Silva Lopes,"6' 3""",240 lbs.,--,,"Mar 08, 1985",http://ufcstats.com/fighter-details/1f8cd7634e8286ff
 Nicolas Dalby,"5' 11""",170 lbs.,"74""",Orthodox,"Nov 16, 1984",http://ufcstats.com/fighter-details/9d19d9e4aa2662e8
 Paul Daley,"5' 9""",170 lbs.,"76""",Orthodox,"Feb 21, 1983",http://ufcstats.com/fighter-details/23725c826c481e7f
@@ -717,11 +826,13 @@ Marko Damiani,"6' 0""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/6e9b5
 Leonardo Damiani,"5' 10""",170 lbs.,"69""",Orthodox,"Aug 30, 1990",http://ufcstats.com/fighter-details/acd870570949d8a2
 Rodrigo Damm,"5' 7""",155 lbs.,"71""",Orthodox,"Feb 03, 1980",http://ufcstats.com/fighter-details/a20d7dfaba74c067
 Carina Damm,"5' 4""",135 lbs.,--,,--,http://ufcstats.com/fighter-details/033343da4c0cff8a
-Danaa Batgerel,"5' 7""",135 lbs.,"70""",Orthodox,"Jul 04, 1989",http://ufcstats.com/fighter-details/3b0a516d2921e0d6
+Batgerel Danaa,"5' 7""",135 lbs.,"70""",Orthodox,"Jul 04, 1989",http://ufcstats.com/fighter-details/3b0a516d2921e0d6
 Cindy Dandois,"5' 7""",135 lbs.,--,Orthodox,"Oct 26, 1984",http://ufcstats.com/fighter-details/9eef6584fab21fbb
+Peter Danesoe,"5' 9""",125 lbs.,"68""",Orthodox,"Sep 01, 2000",http://ufcstats.com/fighter-details/5f119b24c0f9679c
 Jarjis Danho,"6' 3""",265 lbs.,"74""",Orthodox,"Oct 15, 1983",http://ufcstats.com/fighter-details/8614b7134913f5d5
 Raymond Daniels,"6' 2""",185 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/fccb0fee256b7b4d
 Marques Daniels,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/55a80a9365bc107d
+Anvarbek Daniyalbekov,--,185 lbs.,--,,"May 27, 1995",http://ufcstats.com/fighter-details/859e0dafd04fe1ca
 Alexandre Dantas,"6' 2""",238 lbs.,--,Orthodox,"Mar 01, 1979",http://ufcstats.com/fighter-details/8dc46e9a7895ce1a
 Eduardo Dantas,"5' 10""",135 lbs.,--,,"Feb 03, 1989",http://ufcstats.com/fighter-details/676a2e5ec4d7338c
 Mac Danzig,"5' 8""",155 lbs.,"70""",Orthodox,"Jan 02, 1980",http://ufcstats.com/fighter-details/86f582852a5b240a
@@ -729,7 +840,7 @@ Karen Darabedyan,"5' 7""",155 lbs.,"68""",Orthodox,"Dec 18, 1986",http://ufcstat
 Beneil Dariush,"5' 10""",155 lbs.,"72""",Southpaw,"May 06, 1989",http://ufcstats.com/fighter-details/08af939f41b5a57b
 Sean Daugherty,"6' 0""",175 lbs.,--,,"Dec 04, 1975",http://ufcstats.com/fighter-details/a683f9ddb70aa4bd
 Kyle Daukaus,"6' 3""",185 lbs.,"76""",Southpaw,"Feb 27, 1993",http://ufcstats.com/fighter-details/d6c0cdd7e467c440
-Chris Daukaus,"6' 3""",250 lbs.,"76""",Orthodox,"Sep 25, 1989",http://ufcstats.com/fighter-details/d0aaedcf7ccd0b45
+Chris Daukaus,"6' 3""",205 lbs.,"76""",Orthodox,"Sep 25, 1989",http://ufcstats.com/fighter-details/d0aaedcf7ccd0b45
 Brian Davidson,"5' 6""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/42775dc893603154
 Rick Davis,"5' 9""",155 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/2549d63da9c456cb
 Marcus Davis,"5' 10""",170 lbs.,"70""",Southpaw,"Aug 24, 1973",http://ufcstats.com/fighter-details/b7d524c77c27389b
@@ -761,22 +872,26 @@ Jorge de Oliveira,"5' 8""",155 lbs.,--,Orthodox,"Jan 22, 1980",http://ufcstats.c
 Isabela de Padua,"5' 3""",125 lbs.,"64""",Orthodox,"Sep 04, 1991",http://ufcstats.com/fighter-details/e0f959f65d0406b4
 Gloria de Paula,"5' 5""",115 lbs.,"67""",Orthodox,"Jun 10, 1995",http://ufcstats.com/fighter-details/5dd180c8b3196786
 Germaine de Randamie,"5' 9""",135 lbs.,"71""",Orthodox,"Apr 24, 1984",http://ufcstats.com/fighter-details/1d239d571e342453
+Reinier de Ridder,--,185 lbs.,--,,"Sep 07, 1990",http://ufcstats.com/fighter-details/d549cefc7c54ab78
 Crezio de Souza,--,170 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/3746e21bb508391a
+Carl Deaton,"5' 7""",155 lbs.,"69""",Orthodox,"Nov 24, 1989",http://ufcstats.com/fighter-details/914a897455693650
 Tom DeBlass,"6' 0""",185 lbs.,--,Orthodox,"May 14, 1982",http://ufcstats.com/fighter-details/0bcfe2513cb3bc39
 Issac DeJesus,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/0e2c2daf11b5d8f2
 RafaelDel Real,"5' 11""",225 lbs.,--,,--,http://ufcstats.com/fighter-details/e82b2adcaeff71ec
 Shane del Rosario,"6' 4""",250 lbs.,--,Southpaw,"Sep 23, 1983",http://ufcstats.com/fighter-details/85980f5da429c0a6
+Wallen Del Rosario,"5' 4""",125 lbs.,"67""",Orthodox,"Mar 18, 1993",http://ufcstats.com/fighter-details/a62f85f6a6c19a4c
 Humberto DeLeon,--,135 lbs.,--,,"Nov 12, 1989",http://ufcstats.com/fighter-details/bfaf4c87936b4fae
 Rolando Delgado,"6' 3""",155 lbs.,"77""",Orthodox,"Nov 22, 1981",http://ufcstats.com/fighter-details/37b1696e6d115957
 Israel Delgado,"5' 10""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/01f4bcd26ac08ad5
+Jose Delgado,"5' 11""",145 lbs.,"73""",Switch,"Apr 21, 1998",http://ufcstats.com/fighter-details/7d6ceff6747f2de2
 Ante Delija,"6' 4""",245 lbs.,--,Orthodox,"Aug 07, 1990",http://ufcstats.com/fighter-details/7d8435c56043b0ae
-Jack Della,"5' 11""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/2c0dbe5db59013a7
 Jack Della Maddalena,"5' 11""",170 lbs.,"73""",Switch,"Sep 10, 1996",http://ufcstats.com/fighter-details/6b453bc35a823c3f
 Roland Delorme,"5' 9""",135 lbs.,"71""",Orthodox,"Dec 18, 1983",http://ufcstats.com/fighter-details/173acb3f920082b8
 Jon Delos Reyes,"5' 6""",125 lbs.,"67""",Orthodox,"Aug 19, 1987",http://ufcstats.com/fighter-details/0d0351c20169a499
 Jason DeLucia,"5' 11""",190 lbs.,--,Southpaw,"Jul 24, 1969",http://ufcstats.com/fighter-details/6ceff86fae4f6b3b
+Yadier DelValle,"5' 9""",145 lbs.,"69""",Southpaw,"Jul 29, 1996",http://ufcstats.com/fighter-details/70380ccdc81915b8
 Justin DeMoney,--,170 lbs.,--,,"Jul 01, 1985",http://ufcstats.com/fighter-details/985bca5a097fb3f4
-Vanessa Demopoulos,"5' 2""",125 lbs.,"59""",Orthodox,"Sep 22, 1988",http://ufcstats.com/fighter-details/2c483cf443f38ece
+Vanessa Demopoulos,"5' 2""",115 lbs.,"59""",Orthodox,"Sep 22, 1988",http://ufcstats.com/fighter-details/2c483cf443f38ece
 Chris Dempsey,"5' 10""",185 lbs.,"72""",Orthodox,"Sep 08, 1987",http://ufcstats.com/fighter-details/dfae5da5676e4194
 Nick Denis,"5' 7""",135 lbs.,--,Orthodox,"Oct 11, 1983",http://ufcstats.com/fighter-details/e4aaaa34535e32b6
 Thomas Denny,"5' 10""",170 lbs.,--,Orthodox,"Apr 19, 1971",http://ufcstats.com/fighter-details/a11a6ee8eeb03c18
@@ -785,6 +900,7 @@ Jason Dent,"5' 10""",155 lbs.,"71""",Orthodox,"Jun 12, 1980",http://ufcstats.com
 Mackenzie Dern,"5' 4""",115 lbs.,"63""",Orthodox,"Mar 24, 1993",http://ufcstats.com/fighter-details/7447e9f28508106a
 Booker DeRousse,"6' 2""",205 lbs.,--,,"Mar 23, 1981",http://ufcstats.com/fighter-details/f2c91b67f71bbeab
 Tony DeSouza,"6' 0""",170 lbs.,"70""",Southpaw,"Jul 26, 1974",http://ufcstats.com/fighter-details/6ad9058b7c7898b0
+Robelis Despaigne,"6' 7""",265 lbs.,"84""",Orthodox,"Sep 09, 1988",http://ufcstats.com/fighter-details/140567899d98978a
 Cory Devela,"5' 0""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/48544433372ecfa6
 John Devine,--,--,--,,--,http://ufcstats.com/fighter-details/2bcc39af95d6f2e8
 Edwin DeWees,"6' 1""",185 lbs.,--,Orthodox,"Aug 07, 1982",http://ufcstats.com/fighter-details/75bbd2206a15319f
@@ -794,15 +910,17 @@ Cyrille Diabate,"6' 6""",205 lbs.,"81""",Southpaw,"Oct 06, 1973",http://ufcstats
 Thomas Diagne,"6' 1""",154 lbs.,--,,"Sep 03, 1983",http://ufcstats.com/fighter-details/8567466ae167216b
 Marc Diakiese,"5' 10""",155 lbs.,"73""",Orthodox,"Mar 16, 1993",http://ufcstats.com/fighter-details/32c355b04fc57f3a
 Tyler Diamond,"5' 7""",145 lbs.,"69""",Orthodox,"Mar 18, 1991",http://ufcstats.com/fighter-details/f5f6419c5f00abad
-Blood Diamond,"5' 11""",170 lbs.,"73""",Switch,"Jul 10, 1988",http://ufcstats.com/fighter-details/9edf2c9082cc2cd8
+Blood Diamond,"5' 11""",170 lbs.,"76""",Switch,"Jul 10, 1988",http://ufcstats.com/fighter-details/9edf2c9082cc2cd8
 Eldo Xavier Dias,"5' 11""",180 lbs.,--,,"Jul 16, 1964",http://ufcstats.com/fighter-details/ee5df903f80c6816
 Rafael Dias,"5' 9""",145 lbs.,--,Orthodox,"Oct 20, 1979",http://ufcstats.com/fighter-details/b5abaa65f87938eb
 Hacran Dias,"5' 8""",155 lbs.,"69""",Orthodox,"Jun 16, 1984",http://ufcstats.com/fighter-details/ed209f6618c82e41
+Victor Dias,"5' 6""",125 lbs.,"69""",Orthodox,"Dec 26, 1990",http://ufcstats.com/fighter-details/f7202b3130421d27
 Nick Diaz,"6' 1""",170 lbs.,"76""",Southpaw,"Aug 02, 1983",http://ufcstats.com/fighter-details/f57a8a52ca401ed9
 Nate Diaz,"6' 0""",170 lbs.,"76""",Southpaw,"Apr 16, 1985",http://ufcstats.com/fighter-details/8355922d564b152c
 Michael Diaz,--,260 lbs.,--,,--,http://ufcstats.com/fighter-details/5e7a48e469770615
 Ryan Diaz,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/ceee5dd37253199a
 Adrian Diaz,"5' 10""",145 lbs.,--,Southpaw,"Apr 26, 1988",http://ufcstats.com/fighter-details/bfa8f263815cfa2e
+Ozzy Diaz,"6' 4""",205 lbs.,"79""",Orthodox,"Nov 22, 1990",http://ufcstats.com/fighter-details/6967153c7edb4d87
 Mark Dickman,"5' 9""",145 lbs.,--,,"Jul 19, 1984",http://ufcstats.com/fighter-details/2482ef3331a82e75
 Josh Diekmann,"5' 4""",246 lbs.,--,,"Oct 09, 1976",http://ufcstats.com/fighter-details/414bddf0c80c41e1
 Kyle Dietz,"5' 8""",135 lbs.,--,Orthodox,"Apr 29, 1986",http://ufcstats.com/fighter-details/31da66df48c0c1a0
@@ -810,7 +928,9 @@ Seth Dikun,"5' 10""",135 lbs.,"69""",Orthodox,"Aug 05, 1980",http://ufcstats.com
 TJ Dillashaw,"5' 6""",135 lbs.,"67""",Orthodox,"Feb 07, 1986",http://ufcstats.com/fighter-details/c849740a3ff51931
 Ralph Dillon,"6' 2""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/b4f7a2d8ecc5e0c3
 Drew Dimanlig,--,185 lbs.,--,,--,http://ufcstats.com/fighter-details/cc2ad11b1f9d818b
+Ding Meng,"6' 2""",170 lbs.,"73""",Orthodox,"Sep 27, 1994",http://ufcstats.com/fighter-details/e0664abaa023fd6f
 Rodolfo Marques Diniz,"5' 6""",135 lbs.,--,,"Jan 23, 1984",http://ufcstats.com/fighter-details/2d2239d0f6fa83dd
+Jhonata Diniz,"6' 4""",254 lbs.,"79""",Orthodox,"Jun 23, 1991",http://ufcstats.com/fighter-details/25f9a5f3e8a52618
 Helio Dipp,"6' 5""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/73eb2a552c92a821
 Rico DiSciullo,"5' 8""",135 lbs.,--,Orthodox,"Oct 12, 1986",http://ufcstats.com/fighter-details/ec7f7263bf36579b
 Matt Dixon,"5' 10""",170 lbs.,"75""",Switch,"Oct 09, 1995",http://ufcstats.com/fighter-details/1db445a4468447d0
@@ -830,23 +950,29 @@ CB Dollaway,"6' 2""",185 lbs.,"76""",Orthodox,"Aug 10, 1983",http://ufcstats.com
 Dennis Dombrow,--,145 lbs.,--,,"Mar 17, 1986",http://ufcstats.com/fighter-details/4145caa2c999fbac
 OJ Dominguez,--,--,--,,--,http://ufcstats.com/fighter-details/1a50e734bb54861a
 John Donaldson,"5' 8""",145 lbs.,--,,"Jul 09, 1992",http://ufcstats.com/fighter-details/1c610f900f9884ab
+Dong Huaxiang,"5' 3""",115 lbs.,"61""",Switch,"Aug 21, 1998",http://ufcstats.com/fighter-details/bad82b681819b272
 Cody Donovan,"6' 3""",205 lbs.,"74""",Orthodox,"Feb 20, 1981",http://ufcstats.com/fighter-details/7bc96507e4b38d3b
 Houston Dorr,"6' 1""",210 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/312f47c3d2f83ffa
-Rafael Dos Anjos,"5' 8""",155 lbs.,"70""",Southpaw,"Oct 26, 1984",http://ufcstats.com/fighter-details/6a2f7c151031653d
+Rafael Dos Anjos,"5' 8""",170 lbs.,"70""",Southpaw,"Oct 26, 1984",http://ufcstats.com/fighter-details/6a2f7c151031653d
 Junior Dos Santos,"6' 4""",238 lbs.,"77""",Orthodox,"Jan 30, 1984",http://ufcstats.com/fighter-details/63def5a5662a6917
 Geronimo dos Santos,"6' 3""",264 lbs.,--,Orthodox,"Aug 17, 1980",http://ufcstats.com/fighter-details/b51f6791c794e289
 Antonio Dos Santos,"5' 10""",185 lbs.,--,Orthodox,"Jul 21, 1988",http://ufcstats.com/fighter-details/81b8b3fb019dc69d
 Anderson Dos Santos,"5' 5""",135 lbs.,"70""",Orthodox,"Jul 24, 1985",http://ufcstats.com/fighter-details/bbc9ab95fa766493
+Acacio Dos Santos,"6' 4""",205 lbs.,"79""",Orthodox,"Sep 29, 1991",http://ufcstats.com/fighter-details/957562fdf68a725a
+Rayanne dos Santos,"5' 2""",115 lbs.,"62""",Orthodox,"Jun 08, 1995",http://ufcstats.com/fighter-details/02bb48869eb7ac8f
+Felipe dos Santos,"5' 7""",125 lbs.,"70""",Orthodox,"Sep 11, 2000",http://ufcstats.com/fighter-details/5cdf5339728f580d
 Tiago dos Santos e Silva,"5' 9""",145 lbs.,"70""",Orthodox,"Apr 12, 1987",http://ufcstats.com/fighter-details/8ce87f7e3a9baed2
 Oleksandr Doskalchuk,"5' 6""",125 lbs.,--,Southpaw,"Mar 13, 1990",http://ufcstats.com/fighter-details/86cb6f5b1ca98dc0
 David Douglas,"5' 11""",155 lbs.,--,,"Aug 16, 1981",http://ufcstats.com/fighter-details/7cf0944b88966118
 Damion Douglas,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/ce3b669e39418414
+Cedric Doumbe,"5' 10""",170 lbs.,--,,"Aug 13, 1992",http://ufcstats.com/fighter-details/5159e6ee100c717e
 John Dowdy,--,--,--,,--,http://ufcstats.com/fighter-details/e780ccc79a209985
 Jordan Dowdy,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/0d9312337fdce39a
 Danny Downes,"6' 0""",155 lbs.,"72""",Orthodox,"Apr 08, 1986",http://ufcstats.com/fighter-details/a66395395b5f1394
 Derek Downey,"6' 1""",185 lbs.,--,Orthodox,"Apr 27, 1980",http://ufcstats.com/fighter-details/b05086131c6f5dc5
 John Doyle,"5' 11""",205 lbs.,--,Orthodox,"Nov 21, 1976",http://ufcstats.com/fighter-details/0509b954421bb327
 Edson Drago,"6' 4""",220 lbs.,--,Orthodox,"Aug 29, 1977",http://ufcstats.com/fighter-details/f9c7fe2682af3802
+Anthony Drilich,"5' 5""",125 lbs.,"65""",Southpaw,"Mar 17, 1994",http://ufcstats.com/fighter-details/c2c4052f58f54988
 Kyle Driscoll,"5' 11""",145 lbs.,"74""",Orthodox,"Sep 23, 1994",http://ufcstats.com/fighter-details/e5e148d4363deff8
 Chris Drumm,"5' 8""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/5fd834edd92c9e50
 Tomasz Drwal,"6' 1""",205 lbs.,"76""",Orthodox,"Jan 22, 1982",http://ufcstats.com/fighter-details/679a9054e2815943
@@ -855,15 +981,24 @@ Dricus Du Plessis,"6' 1""",185 lbs.,"76""",Switch,"Jan 14, 1994",http://ufcstats
 Hugo Duarte,"6' 0""",240 lbs.,--,Orthodox,"Aug 09, 1968",http://ufcstats.com/fighter-details/706404da0775dcbc
 Antonio Duarte,"5' 7""",135 lbs.,--,,--,http://ufcstats.com/fighter-details/29b5d32584e02d8d
 Joe Duarte,--,155 lbs.,--,,"Jan 25, 1977",http://ufcstats.com/fighter-details/454c3e9d4cd4a1b3
+Yuneisy Duben,"5' 4""",125 lbs.,"65""",Orthodox,"Jul 08, 1996",http://ufcstats.com/fighter-details/c3d2b9bcb4cead6b
+Matthieu Duclos,"6' 3""",185 lbs.,"77""",Orthodox,"Apr 04, 1995",http://ufcstats.com/fighter-details/ec322adbabbfa6e7
+Emily Ducote,"5' 2""",115 lbs.,"63""",Orthodox,"Jan 01, 1994",http://ufcstats.com/fighter-details/02f8fedc18cbd26c
+Viktoriia Dudakova,"5' 5""",115 lbs.,"67""",Orthodox,"Jan 26, 1999",http://ufcstats.com/fighter-details/6c9b66b43663f2f7
 Milana Dudieva,"5' 3""",135 lbs.,--,Orthodox,"Aug 04, 1989",http://ufcstats.com/fighter-details/072a10e85f7d4bff
 Adin Duenas,"5' 6""",145 lbs.,--,,"Jul 02, 1988",http://ufcstats.com/fighter-details/cb6c45b26b0a877a
 Todd Duffee,"6' 3""",260 lbs.,"78""",Orthodox,"Dec 06, 1985",http://ufcstats.com/fighter-details/bda04c573563cc2e
 Joe Duffy,"5' 10""",155 lbs.,"73""",Orthodox,"Feb 18, 1988",http://ufcstats.com/fighter-details/654ae722109a0d31
+Jack Duffy,"5' 7""",125 lbs.,"69""",Switch,"Oct 02, 1995",http://ufcstats.com/fighter-details/cea51876d8a514a0
 Alexis Dufresne,"5' 9""",135 lbs.,--,Orthodox,"Aug 31, 1990",http://ufcstats.com/fighter-details/4ae4049426e0161d
 Jessamyn Duke,"5' 11""",135 lbs.,"73""",Orthodox,"Jun 24, 1986",http://ufcstats.com/fighter-details/a7ddae0be8b78147
+Islam Dulatov,"6' 3""",170 lbs.,"75""",Orthodox,"Aug 02, 1998",http://ufcstats.com/fighter-details/e803242fb2e41112
+Isaac Dulgarian,"5' 7""",145 lbs.,"71""",Orthodox,"Jul 04, 1996",http://ufcstats.com/fighter-details/a57cb948c4c70a47
 Kelly Dullanty,"5' 8""",155 lbs.,--,Orthodox,"Nov 04, 1977",http://ufcstats.com/fighter-details/1a225f04aa6e0739
-Norma Dumont,"5' 7""",145 lbs.,"67""",Orthodox,"Oct 01, 1990",http://ufcstats.com/fighter-details/d3f5d33d61cd00c9
+Sedriques Dumas,"6' 2""",185 lbs.,"79""",Orthodox,"Aug 06, 1995",http://ufcstats.com/fighter-details/4e6738062d469256
+Norma Dumont,"5' 7""",135 lbs.,"67""",Orthodox,"Oct 01, 1990",http://ufcstats.com/fighter-details/d3f5d33d61cd00c9
 Chris Duncan,"5' 10""",155 lbs.,"71""",Orthodox,"May 10, 1993",http://ufcstats.com/fighter-details/fd406a32a6fb3a29
+Christian Leroy Duncan,"6' 2""",185 lbs.,"79""",Switch,"Jul 24, 1995",http://ufcstats.com/fighter-details/a93f94c923c3a9cb
 Evan Dunham,"5' 10""",155 lbs.,"70""",Southpaw,"Dec 18, 1981",http://ufcstats.com/fighter-details/e5c9de15bb58b1c6
 Alex Dunworth,"5' 8""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/31732a614e7a3d1d
 Tom Duquesnoy,"5' 7""",135 lbs.,"68""",Orthodox,"Jun 21, 1993",http://ufcstats.com/fighter-details/e979c76341f19b22
@@ -885,6 +1020,7 @@ Maurice Eazel,"5' 7""",135 lbs.,--,,--,http://ufcstats.com/fighter-details/4acb9
 Vincent Eazelle,"5' 11""",155 lbs.,--,,"Dec 07, 1980",http://ufcstats.com/fighter-details/ec421d5de0aea624
 Ross Ebanez,"5' 9""",154 lbs.,--,Southpaw,"May 18, 1975",http://ufcstats.com/fighter-details/a5b0bd216d8ba84e
 Brian Ebersole,"6' 0""",170 lbs.,"73""",Southpaw,"Nov 27, 1980",http://ufcstats.com/fighter-details/32ba186f4b0e3267
+Roybert Echeverria,"5' 5""",125 lbs.,"67""",Switch,"Aug 21, 1995",http://ufcstats.com/fighter-details/20b13e96668caaa4
 Mark Eddiva,"5' 8""",145 lbs.,"68""",Orthodox,"Feb 16, 1986",http://ufcstats.com/fighter-details/40ff198adda94b9f
 Frankie Edgar,"5' 6""",135 lbs.,"68""",Orthodox,"Oct 16, 1981",http://ufcstats.com/fighter-details/f2688492b9a525a3
 Abdul-Kerim Edilov,"6' 2""",205 lbs.,--,Orthodox,"Nov 25, 1991",http://ufcstats.com/fighter-details/37e03538c960bac6
@@ -901,12 +1037,15 @@ Justin Eilers,"6' 1""",235 lbs.,--,Orthodox,"Jun 28, 1978",http://ufcstats.com/f
 Jon Olav Einemo,"6' 6""",253 lbs.,--,Orthodox,"Dec 10, 1975",http://ufcstats.com/fighter-details/0577808d22dfe79c
 Per Eklund,"5' 10""",155 lbs.,"72""",Orthodox,--,http://ufcstats.com/fighter-details/58bc81376286b3d3
 John Elam,--,--,--,,--,http://ufcstats.com/fighter-details/22d80fb67e50ab0b
+Evan Elder,"5' 10""",155 lbs.,"72""",Switch,"Apr 11, 1997",http://ufcstats.com/fighter-details/d9a56ecb6e94f02e
 John Paul Elias,"6' 4""",205 lbs.,--,,--,http://ufcstats.com/fighter-details/e873203fd50542f6
+Joao Elias,"5' 3""",125 lbs.,"64""",Southpaw,"Jan 08, 1995",http://ufcstats.com/fighter-details/1a064688481f66e1
 Saul Elizondo,"5' 7""",135 lbs.,--,,"Jul 17, 1985",http://ufcstats.com/fighter-details/e295b96f135d758a
 Darren Elkins,"5' 10""",145 lbs.,"71""",Orthodox,"May 16, 1984",http://ufcstats.com/fighter-details/92a9aa9c93192871
 Jake Ellenberger,"5' 9""",170 lbs.,"71""",Orthodox,"Mar 28, 1985",http://ufcstats.com/fighter-details/d81ac739417d7f53
 Joe Ellenberger,"5' 9""",155 lbs.,"72""",Orthodox,"Mar 28, 1985",http://ufcstats.com/fighter-details/8e8e4487c621aa1c
 Tim Elliott,"5' 7""",125 lbs.,"66""",Southpaw,"Dec 24, 1986",http://ufcstats.com/fighter-details/c96d9178c9ed9e62
+Oban Elliott,"6' 0""",170 lbs.,"72""",Orthodox,"Dec 19, 1997",http://ufcstats.com/fighter-details/6b56e94a59b7b134
 Eddy Ellis,"5' 9""",170 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/e60d773a0a42048a
 Lisa Ellis,"5' 4""",115 lbs.,--,,"Nov 15, 1982",http://ufcstats.com/fighter-details/77350fd0e6d1dba8
 Anna Elmose,"5' 3""",115 lbs.,--,Orthodox,"Oct 06, 1984",http://ufcstats.com/fighter-details/1536a25e16fc299b
@@ -929,9 +1068,13 @@ Ian Entwistle,"5' 5""",135 lbs.,--,Orthodox,"Nov 19, 1986",http://ufcstats.com/f
 Andy Enz,"6' 3""",185 lbs.,"78""",Orthodox,"Aug 15, 1991",http://ufcstats.com/fighter-details/993d385f5a475375
 Won Jin Eoh,"5' 7""",160 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/bc7cf284c1c2f16e
 Josh Epps,--,130 lbs.,--,,"Aug 23, 1986",http://ufcstats.com/fighter-details/984b0c4c6e773a1c
+Abdellah Er-Ramy,"6' 0""",185 lbs.,"74""",Orthodox,"Sep 19, 1996",http://ufcstats.com/fighter-details/b593cd58b0afffb0
+Steve Erceg,"5' 8""",125 lbs.,"68""",Orthodox,"Jul 27, 1995",http://ufcstats.com/fighter-details/32ab52e5de93092d
 Tom Erikson,"6' 3""",280 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/7b9a85e5ff31ef47
 Konstantin Erokhin,"5' 11""",230 lbs.,--,Orthodox,"Jan 31, 1983",http://ufcstats.com/fighter-details/22061ff217907c78
 Julian Erosa,"6' 1""",145 lbs.,"74""",Southpaw,"Jul 31, 1989",http://ufcstats.com/fighter-details/902ec2cc48c8ae8a
+Jarno Errens,"5' 11""",145 lbs.,"73""",Orthodox,"Nov 17, 1994",http://ufcstats.com/fighter-details/082eba4cd80f736f
+Ivan Erslan,"6' 2""",205 lbs.,"72""",Orthodox,"Nov 15, 1991",http://ufcstats.com/fighter-details/64ad3e3b0efa30bb
 Nick Ertl,"5' 9""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/74061adb224be3cc
 Chel Erwin-Davis,"6' 0""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/c26ea30823f37316
 Bobby Escalante,--,130 lbs.,--,,--,http://ufcstats.com/fighter-details/f7ede18b4ec4ec1f
@@ -941,10 +1084,12 @@ Cole Escovedo,"5' 7""",135 lbs.,"72""",Orthodox,"Aug 30, 1981",http://ufcstats.c
 Efrain Escudero,"5' 9""",155 lbs.,"71""",Orthodox,"Jan 15, 1986",http://ufcstats.com/fighter-details/83fd97284f4bb4a4
 Evan Esguerra,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/ed220e87bef0cc64
 Carla Esparza,"5' 1""",115 lbs.,"63""",Orthodox,"Oct 10, 1987",http://ufcstats.com/fighter-details/d910665038efc639
-Juan Espino,"6' 3""",255 lbs.,"80""",,"Oct 09, 1980",http://ufcstats.com/fighter-details/ccf5dc41417e9daf
+Juan Espino,"6' 3""",255 lbs.,"80""",Orthodox,"Oct 09, 1980",http://ufcstats.com/fighter-details/ccf5dc41417e9daf
 Jordan Espinosa,"5' 6""",125 lbs.,"69""",Orthodox,"Nov 08, 1989",http://ufcstats.com/fighter-details/215a70f073a7b726
 Jodie Esquibel,"5' 1""",115 lbs.,"64""",Orthodox,"May 07, 1986",http://ufcstats.com/fighter-details/411539901068522f
+Rafael Estevam,"5' 8""",125 lbs.,"69""",Orthodox,"Aug 10, 1996",http://ufcstats.com/fighter-details/83455a9d17f57dae
 Achilles Estremadura,"5' 10""",155 lbs.,"68""",Orthodox,"Mar 11, 1992",http://ufcstats.com/fighter-details/41f3cfdab0b22236
+Shaun Etchell,"5' 7""",125 lbs.,"68""",Switch,"Aug 05, 1993",http://ufcstats.com/fighter-details/ea9bfe9c25037bba
 Terry Etim,"6' 1""",155 lbs.,"73""",Orthodox,"Jan 11, 1986",http://ufcstats.com/fighter-details/33011768c3c4dc9a
 Fred Ettish,"6' 0""",180 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/8d5daf67983b65ba
 Scott Ettling,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/74b5736f1df40be3
@@ -959,20 +1104,21 @@ Movsar Evloev,"5' 7""",145 lbs.,"72""",Orthodox,"Feb 11, 1994",http://ufcstats.c
 Andre Ewell,"5' 8""",145 lbs.,"75""",Southpaw,"Jan 21, 1988",http://ufcstats.com/fighter-details/5f6f049d54728e88
 Neal Ewing,--,185 lbs.,--,,"Sep 30, 1985",http://ufcstats.com/fighter-details/0798f558681d0eb5
 Jessica Eye,"5' 6""",125 lbs.,"66""",Orthodox,"Jul 27, 1986",http://ufcstats.com/fighter-details/f72465a784c1b084
-Edward Faaloloto,--,155 lbs.,"70""",,"Jul 15, 1984",http://ufcstats.com/fighter-details/6224e8d0a34264eb
+Edward Faaloloto,--,155 lbs.,"70""",Orthodox,"Jul 15, 1984",http://ufcstats.com/fighter-details/6224e8d0a34264eb
 Urijah Faber,"5' 6""",135 lbs.,"67""",Orthodox,"May 14, 1979",http://ufcstats.com/fighter-details/78114b7199cef90c
-Melinda Fabian,"5' 6""",125 lbs.,"66""",,"Jun 25, 1987",http://ufcstats.com/fighter-details/8c020156779f7888
+Melinda Fabian,"5' 6""",125 lbs.,"66""",Orthodox,"Jun 25, 1987",http://ufcstats.com/fighter-details/8c020156779f7888
 Wagnney Fabiano,"5' 6""",145 lbs.,"69""",Southpaw,"Jul 14, 1975",http://ufcstats.com/fighter-details/40389d39a92f5bfa
 Bartosz Fabinski,"6' 0""",170 lbs.,"75""",Orthodox,"Apr 26, 1986",http://ufcstats.com/fighter-details/e17ac6410c8377f4
 Ron Faircloth,"5' 9""",205 lbs.,--,Orthodox,"Aug 16, 1979",http://ufcstats.com/fighter-details/453ee00c3e1ae9dd
 Jason Fairn,"6' 1""",230 lbs.,--,,--,http://ufcstats.com/fighter-details/adea9f0090aa8e14
 Zarah Fairn,"5' 8""",135 lbs.,"72""",Orthodox,"Dec 10, 1983",http://ufcstats.com/fighter-details/862b0b3375aa4b6e
-Rinat Fakhretdinov,"6' 0""",185 lbs.,--,,"Sep 28, 1991",http://ufcstats.com/fighter-details/8f765fd5775a8873
+Rinat Fakhretdinov,"6' 0""",170 lbs.,"74""",Orthodox,"Sep 28, 1991",http://ufcstats.com/fighter-details/8f765fd5775a8873
 Maiquel Falcao,"5' 11""",185 lbs.,--,Orthodox,"Mar 08, 1981",http://ufcstats.com/fighter-details/d58478ded5534695
 Pedro Falcao,"5' 6""",135 lbs.,"66""",Orthodox,"Jul 30, 1992",http://ufcstats.com/fighter-details/f7be1db194e03d7e
 Brodie Farber,"6' 1""",170 lbs.,--,Orthodox,"Jul 05, 1980",http://ufcstats.com/fighter-details/91d73ee59347ac16
 Joao Paulo Faria,"5' 9""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/04e9955f33e0c267
 Kalindra Faria,"5' 7""",125 lbs.,--,Switch,"Jul 23, 1986",http://ufcstats.com/fighter-details/27b164b0d1833df0
+Jair Farias,"6' 1""",145 lbs.,"76""",Orthodox,"Mar 16, 1993",http://ufcstats.com/fighter-details/431262bbc69215dc
 Chance Farrar,"5' 9""",145 lbs.,--,Southpaw,"Sep 11, 1975",http://ufcstats.com/fighter-details/49c7236c737d7e59
 Rico Farrington,"6' 4""",170 lbs.,"79""",Southpaw,"Jun 19, 1989",http://ufcstats.com/fighter-details/f89e6e66b9b112de
 Kelly Faszholz,"5' 8""",135 lbs.,--,Orthodox,"Apr 09, 1985",http://ufcstats.com/fighter-details/9c42a0de8e012870
@@ -980,33 +1126,44 @@ Rodney Faverus,"6' 0""",215 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-deta
 Paul Felder,"5' 11""",155 lbs.,"70""",Orthodox,"Apr 25, 1984",http://ufcstats.com/fighter-details/e5010b1b94ca5755
 Carlos Felipe,"6' 0""",245 lbs.,"75""",Orthodox,"Jan 12, 1995",http://ufcstats.com/fighter-details/a2ea77e974c5889f
 JP Felty,--,170 lbs.,--,,"Apr 28, 1979",http://ufcstats.com/fighter-details/954e3f4e2b0e6510
+Feng Pengchao,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/86597694317e5e1b
+Feng Xiaocan,"5' 7""",115 lbs.,"66""",Southpaw,"Dec 27, 2001",http://ufcstats.com/fighter-details/c940b42df95bbd28
 Kevin Ferguson,"6' 2""",235 lbs.,"77""",Orthodox,"Feb 08, 1974",http://ufcstats.com/fighter-details/27541033b97c076d
 Rhadi Ferguson,"5' 7""",205 lbs.,--,,--,http://ufcstats.com/fighter-details/15f4550e017f6c7d
-Tony Ferguson,"5' 11""",155 lbs.,"76""",Orthodox,"Feb 12, 1984",http://ufcstats.com/fighter-details/22a92d7f62195791
+Tony Ferguson,"5' 11""",170 lbs.,"76""",Orthodox,"Feb 12, 1984",http://ufcstats.com/fighter-details/22a92d7f62195791
 Josh Ferguson,"5' 5""",125 lbs.,--,Orthodox,"May 13, 1988",http://ufcstats.com/fighter-details/b0f316c60f8d3b47
 CJ Fernandes,"6' 2""",170 lbs.,--,,"Nov 13, 1977",http://ufcstats.com/fighter-details/979f7edbb6980b0d
 Bibiano Fernandes,"5' 7""",139 lbs.,--,Orthodox,"Mar 30, 1980",http://ufcstats.com/fighter-details/cbc071cb20ea59c7
+Gabriella Fernandes,"5' 6""",125 lbs.,"66""",Southpaw,"Aug 13, 1993",http://ufcstats.com/fighter-details/a6eb54ae17a551be
+Kaue Fernandes,"5' 9""",155 lbs.,"73""",Orthodox,"Mar 17, 1995",http://ufcstats.com/fighter-details/ec13c393d029297d
+Emily Fernandez,--,--,--,,--,http://ufcstats.com/fighter-details/7ee1babb99f30115
+Lucas Fernando,"6' 3""",185 lbs.,"80""",,"Jan 10, 1997",http://ufcstats.com/fighter-details/3df223aeaacecf3f
 Alexandre Ferreira,"5' 7""",205 lbs.,--,Orthodox,"Apr 25, 1979",http://ufcstats.com/fighter-details/28ba5f27e473420c
 Cezar Ferreira,"6' 1""",185 lbs.,"78""",Southpaw,"Feb 15, 1985",http://ufcstats.com/fighter-details/dbc17725b887860a
 Diego Ferreira,"5' 9""",155 lbs.,"74""",Orthodox,"Jan 18, 1985",http://ufcstats.com/fighter-details/f53d4f21d1b5f2dc
-Erisson Ferreira da Silva,"5' 6""",125 lbs.,"70""",Orthodox,"May 03, 1991",http://ufcstats.com/fighter-details/1c2a8915f8431507
+Erisson Ferreira,"5' 6""",125 lbs.,"70""",Orthodox,"May 03, 1991",http://ufcstats.com/fighter-details/1c2a8915f8431507
+Brunno Ferreira,"5' 10""",185 lbs.,"72""",Orthodox,"Nov 04, 1992",http://ufcstats.com/fighter-details/1e719d4b676dc19a
 Scott Ferrozzo,"5' 11""",323 lbs.,--,Orthodox,"Apr 26, 1965",http://ufcstats.com/fighter-details/977081bc01197656
 Timo Feucht,"6' 3""",205 lbs.,"79""",Orthodox,"Jan 18, 1996",http://ufcstats.com/fighter-details/8c21eb9fd7c4c203
 Andre Fialho,"6' 0""",170 lbs.,"74""",Orthodox,"Apr 07, 1994",http://ufcstats.com/fighter-details/33efaf2d0941cfcf
 Drew Fickett,"5' 10""",155 lbs.,"70""",Orthodox,"Dec 14, 1979",http://ufcstats.com/fighter-details/d814f5192e58fb2f
 Scott Fiedler,"6' 4""",235 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/0ec821423baa26bd
 Ron Fields,"6' 2""",200 lbs.,--,Orthodox,"Nov 18, 1974",http://ufcstats.com/fighter-details/6e380a4d73ab4f0e
-Deiveson Figueiredo,"5' 5""",125 lbs.,"68""",Orthodox,"Dec 18, 1987",http://ufcstats.com/fighter-details/aa72b0f831d0bfe5
-Francisco Figueiredo,"5' 6""",135 lbs.,"68""",Southpaw,"Oct 23, 1989",http://ufcstats.com/fighter-details/cdadae5363b66eef
+Michal Figlak,"5' 10""",155 lbs.,"70""",Orthodox,"Aug 15, 1996",http://ufcstats.com/fighter-details/b4c57a8c2b773e82
+Deiveson Figueiredo,"5' 5""",135 lbs.,"68""",Orthodox,"Dec 18, 1987",http://ufcstats.com/fighter-details/aa72b0f831d0bfe5
+Francisco Figueiredo,"5' 6""",125 lbs.,"68""",Southpaw,"Oct 23, 1989",http://ufcstats.com/fighter-details/cdadae5363b66eef
 Anthony Figueroa,"5' 4""",135 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/daff32bc96d1eabf
 Edwin Figueroa,"5' 7""",135 lbs.,"69""",Orthodox,"Jul 31, 1984",http://ufcstats.com/fighter-details/bbfca6d5c27d9cd8
 Paulo Filho,"5' 8""",185 lbs.,--,Southpaw,"May 24, 1978",http://ufcstats.com/fighter-details/2abdead94ce73552
+Jafel Filho,"5' 7""",125 lbs.,"68""",Orthodox,"May 05, 1993",http://ufcstats.com/fighter-details/65adf3856c4d9256
 Andre Fili,"5' 11""",145 lbs.,"74""",Orthodox,"Jun 25, 1990",http://ufcstats.com/fighter-details/8fd808923cffff82
 Mirko Filipovic,"6' 2""",230 lbs.,"73""",Southpaw,"Sep 10, 1974",http://ufcstats.com/fighter-details/c32fb8c0f6471a4d
 Brady Fink,"6' 0""",183 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/997b4f52f76a0b53
 Jesse Finney,"6' 0""",170 lbs.,--,,"Jul 11, 1974",http://ufcstats.com/fighter-details/0496cdac0bc9edd8
 Jan Finney,"5' 8""",135 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/3317823959d32a05
+Torrez Finney,"5' 8""",185 lbs.,"75""",Orthodox,"Oct 24, 1998",http://ufcstats.com/fighter-details/fbb60f24af5d5a02
 Luigi Fioravanti,"5' 8""",170 lbs.,"70""",Orthodox,"Jan 22, 1981",http://ufcstats.com/fighter-details/9583662df31d943f
+Nick Fiore,"5' 10""",155 lbs.,"72""",Orthodox,"Dec 10, 1997",http://ufcstats.com/fighter-details/036e96c1c12b8a59
 Manon Fiorot,"5' 7""",125 lbs.,"65""",Orthodox,"Feb 17, 1990",http://ufcstats.com/fighter-details/34ff304266360297
 Luiz Firmino,"5' 6""",154 lbs.,--,Orthodox,"Mar 18, 1982",http://ufcstats.com/fighter-details/16d09e800ad7ec79
 Spencer Fisher,"5' 7""",155 lbs.,"68""",Southpaw,"May 09, 1976",http://ufcstats.com/fighter-details/f34312c2ccfa0e00
@@ -1017,11 +1174,13 @@ Isi Fitikefu,"5' 10""",205 lbs.,--,,--,http://ufcstats.com/fighter-details/b8dc5
 Rafael Fiziev,"5' 8""",155 lbs.,"71""",Switch,"Mar 05, 1993",http://ufcstats.com/fighter-details/c814b4c899793af6
 Colin Fletcher,"6' 2""",155 lbs.,--,Orthodox,"Jan 08, 1983",http://ufcstats.com/fighter-details/7d09200f6a77b20e
 AJ Fletcher,"5' 10""",170 lbs.,"67""",Switch,"Feb 18, 1997",http://ufcstats.com/fighter-details/725b1abc9a39d873
+Nathan Fletcher,"5' 7""",145 lbs.,"70""",Orthodox,"Jan 03, 1998",http://ufcstats.com/fighter-details/a2d342ffc83913ed
 Jimmy Flick,"5' 7""",125 lbs.,"68""",Orthodox,"Sep 07, 1990",http://ufcstats.com/fighter-details/09e62c450e754913
 Luke Flores,"6' 0""",155 lbs.,"73""",Southpaw,"Mar 17, 1988",http://ufcstats.com/fighter-details/b5f44dcb863f595b
 Ty Flores,"6' 3""",205 lbs.,"73""",Switch,"Dec 22, 1993",http://ufcstats.com/fighter-details/4bb0f74d5e26f89a
 Alejandro Flores,"5' 10""",145 lbs.,"73""",Orthodox,"Aug 06, 1991",http://ufcstats.com/fighter-details/d23d5960ac5e117c
 Kenny Florian,"5' 10""",145 lbs.,"74""",Southpaw,"May 26, 1976",http://ufcstats.com/fighter-details/cb139171ed1b69fe
+Darrius Flowers,"5' 9""",155 lbs.,"71""",Orthodox,"Aug 25, 1994",http://ufcstats.com/fighter-details/65db4065e2bc107d
 Cody Floyd,--,--,--,,"Jul 18, 1988",http://ufcstats.com/fighter-details/8164250600b7c91b
 Bobby Flynn,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/c97fc5fbf7d32b8a
 Caros Fodor,"5' 9""",155 lbs.,"74""",Orthodox,"Jan 07, 1984",http://ufcstats.com/fighter-details/01d2ed8c502e3828
@@ -1033,8 +1192,10 @@ Claudionor Fontinelle,"5' 5""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fight
 Jesse Forbes,"6' 2""",185 lbs.,"75""",Southpaw,"Oct 24, 1984",http://ufcstats.com/fighter-details/947eccadb72f4f6f
 Sterling Ford,"5' 10""",155 lbs.,--,,"Mar 12, 1986",http://ufcstats.com/fighter-details/a71ce6ff0b4a9dbb
 Codale Ford,"5' 9""",170 lbs.,--,,"May 13, 1979",http://ufcstats.com/fighter-details/5340123d826ceadb
+Raheam Forest,"5' 11""",170 lbs.,"73""",Switch,"Jul 11, 1997",http://ufcstats.com/fighter-details/90390dd1b0791e7f
 Jussier Formiga,"5' 5""",125 lbs.,"67""",Orthodox,"Apr 14, 1985",http://ufcstats.com/fighter-details/b102c26727306ab6
 Renee Forte,"5' 7""",155 lbs.,"71""",Orthodox,"Mar 27, 1987",http://ufcstats.com/fighter-details/44bc27bfa76dcd9e
+Brianna Fortino,"5' 0""",115 lbs.,"62""",Southpaw,"Aug 04, 1993",http://ufcstats.com/fighter-details/b53c46f613f6f248
 Marcel Fortuna,"6' 1""",205 lbs.,"74""",Orthodox,"Oct 22, 1985",http://ufcstats.com/fighter-details/d761b3766e38c5db
 Brian Foster,"5' 9""",170 lbs.,"71""",Orthodox,"Apr 03, 1984",http://ufcstats.com/fighter-details/3dc3022232b79c7a
 Xavier Foupa-Pokam,"6' 1""",185 lbs.,--,Open Stance,"Jul 03, 1982",http://ufcstats.com/fighter-details/ec33146e43e58933
@@ -1045,6 +1206,7 @@ Glaico Franca Moreira,"6' 0""",155 lbs.,"77""",Orthodox,"Feb 28, 1991",http://uf
 Francisco France,"6' 0""",205 lbs.,--,,"Jan 21, 1983",http://ufcstats.com/fighter-details/ecfdbf38681a59ba
 John Franchi,"5' 6""",145 lbs.,"67""",Orthodox,"Jul 16, 1982",http://ufcstats.com/fighter-details/b9532d815060de7f
 Rich Franklin,"6' 1""",185 lbs.,"76""",Southpaw,"Oct 05, 1974",http://ufcstats.com/fighter-details/d897897060f10a3a
+Xavier Franklin,"5' 6""",135 lbs.,"66""",Southpaw,"Oct 15, 1996",http://ufcstats.com/fighter-details/90957a918e26bf9c
 Zoila Frausto,"5' 4""",135 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/040d3b4c735541aa
 Stephanie Frausto,"5' 2""",115 lbs.,"61""",Orthodox,"Sep 20, 1990",http://ufcstats.com/fighter-details/fee02819a271c050
 Zane Frazier,"6' 5""",250 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/d3711d3784b76255
@@ -1052,20 +1214,23 @@ Gary Frazier,"6' 0""",245 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-detail
 Justin Frazier,"6' 0""",265 lbs.,"75""",Southpaw,"Jun 15, 1989",http://ufcstats.com/fighter-details/78863e4a28204a6b
 Ian Freeman,"5' 11""",225 lbs.,--,Orthodox,"Nov 10, 1966",http://ufcstats.com/fighter-details/b4bc2e3353a770b5
 Jason Freeman,"6' 2""",225 lbs.,--,,"Sep 02, 1976",http://ufcstats.com/fighter-details/5870bd1eadf4f322
-Willamy Freire,"5' 8""",155 lbs.,--,,"Jul 28, 1987",http://ufcstats.com/fighter-details/f1f37d667bcd0d27
+Willamy Freire,"5' 8""",155 lbs.,--,Orthodox,"Jul 28, 1987",http://ufcstats.com/fighter-details/f1f37d667bcd0d27
 Patricio Freire,"5' 5""",145 lbs.,"65""",,"Jul 07, 1987",http://ufcstats.com/fighter-details/98a58c26c5b1ed17
 Patricky Freire,"5' 7""",155 lbs.,"71""",,"Jun 01, 1986",http://ufcstats.com/fighter-details/90e6dde9113830bd
 JeremyFreitag,"6' 1""",205 lbs.,--,,--,http://ufcstats.com/fighter-details/a47e9ec288c91067
 Rafael Freitas,--,205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/14b9e0f2679a2205
 Donavon Frelow,"5' 7""",135 lbs.,--,Orthodox,"Jan 20, 1985",http://ufcstats.com/fighter-details/9aa56f004b2bca07
+Josh Fremd,"6' 4""",185 lbs.,"76""",Orthodox,"Jan 15, 1994",http://ufcstats.com/fighter-details/ca43de99b07b6b40
 Clay French,"5' 7""",161 lbs.,--,Southpaw,"Oct 07, 1980",http://ufcstats.com/fighter-details/73321668ff977f1b
 Mike French,"5' 10""",145 lbs.,--,,"May 29, 1975",http://ufcstats.com/fighter-details/756f45905fb20cb5
 Matt Frevola,"5' 9""",155 lbs.,"71""",Orthodox,"Jun 11, 1990",http://ufcstats.com/fighter-details/dccb63727f2f5f74
 Jinh Yu Frey,"5' 3""",115 lbs.,"65""",Southpaw,"May 20, 1985",http://ufcstats.com/fighter-details/d05cb1e8d1b885d8
 Artem Frolov,"5' 10""",185 lbs.,--,,"Sep 07, 1991",http://ufcstats.com/fighter-details/ee704df0afd74558
 Sarah Frota,"5' 6""",125 lbs.,"69""",Southpaw,"Apr 14, 1987",http://ufcstats.com/fighter-details/1641ef250e9de19b
+Daniel Frunza,"6' 1""",170 lbs.,"73""",Orthodox,"Apr 13, 1994",http://ufcstats.com/fighter-details/7cec3c4a5e7b6d68
 Don Frye,"6' 1""",219 lbs.,--,Orthodox,"Nov 23, 1965",http://ufcstats.com/fighter-details/271fe91f4ba9d2c5
 Tony Fryklund,"6' 0""",185 lbs.,--,Orthodox,"Mar 26, 1971",http://ufcstats.com/fighter-details/253de74457bd6374
+Adam Fugitt,"6' 1""",170 lbs.,"77""",Southpaw,"Jan 12, 1989",http://ufcstats.com/fighter-details/a01a62132460a98d
 Jesse Fujarczyk,"6' 4""",225 lbs.,--,Southpaw,"Jan 28, 1983",http://ufcstats.com/fighter-details/c3c38c86f5ab9b5c
 Katsuhisa Fujii,"6' 0""",205 lbs.,--,Orthodox,"Aug 15, 1972",http://ufcstats.com/fighter-details/d71d968dc6ecfdaf
 Megumi Fujii,"5' 3""",113 lbs.,--,,"Apr 26, 1974",http://ufcstats.com/fighter-details/fb6c531726447ff3
@@ -1082,6 +1247,7 @@ James Gabert,--,178 lbs.,--,,--,http://ufcstats.com/fighter-details/fcd8b623892b
 Gustavo Gabriel,"5' 6""",125 lbs.,--,Orthodox,"Apr 01, 1994",http://ufcstats.com/fighter-details/fe98f86284a6eeb3
 Claudia Gadelha,"5' 4""",115 lbs.,"63""",Orthodox,"Dec 07, 1988",http://ufcstats.com/fighter-details/ec34349e7dffcde7
 Alavutdin Gadjiev,"6' 2""",185 lbs.,--,Orthodox,"Jun 23, 1982",http://ufcstats.com/fighter-details/a7a79b8efbceaaac
+Magomed Gadzhiyasulov,"6' 2""",205 lbs.,"75""",Orthodox,"Nov 04, 1993",http://ufcstats.com/fighter-details/6e344b71421103da
 Justin Gaethje,"5' 11""",155 lbs.,"70""",Orthodox,"Nov 14, 1988",http://ufcstats.com/fighter-details/9e8f6c728eb01124
 Sheila Gaff,"5' 5""",135 lbs.,--,Orthodox,"Dec 29, 1989",http://ufcstats.com/fighter-details/837d30395faca41e
 Muin Gafurov,"5' 7""",135 lbs.,"68""",Southpaw,"May 17, 1996",http://ufcstats.com/fighter-details/a54660deb6a8489c
@@ -1105,34 +1271,38 @@ Shamil Gamzatov,"6' 2""",205 lbs.,"76""",Orthodox,"Aug 09, 1990",http://ufcstats
 Ariel Gandulla,"5' 11""",205 lbs.,--,Orthodox,"May 07, 1968",http://ufcstats.com/fighter-details/41904fc4d3f5bffc
 Ciryl Gane,"6' 4""",245 lbs.,"81""",Orthodox,"Apr 12, 1990",http://ufcstats.com/fighter-details/787bb1f087ccff8a
 Sean Gannon,"6' 3""",265 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/6d7886b094b471ac
+Junye Gao,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/8b27d25ce0221d60
 Eduardo Garagorri,"5' 9""",145 lbs.,"70""",Orthodox,"May 28, 1989",http://ufcstats.com/fighter-details/7bde387d50829adf
-Cody Garbrandt,"5' 8""",125 lbs.,"65""",Orthodox,"Jul 07, 1991",http://ufcstats.com/fighter-details/d8c7c61b176e3994
+Cody Garbrandt,"5' 8""",135 lbs.,"65""",Orthodox,"Jul 07, 1991",http://ufcstats.com/fighter-details/d8c7c61b176e3994
 Leonard Garcia,"5' 10""",145 lbs.,"68""",Orthodox,"Jul 14, 1979",http://ufcstats.com/fighter-details/917e53fa0adea0d3
 Edgar Garcia,"5' 10""",170 lbs.,"71""",Orthodox,"Feb 22, 1984",http://ufcstats.com/fighter-details/8d49545dadf9b919
 Alejandro Garcia,"5' 7""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/e5dc36e0aba7e9da
 Alex Garcia,"5' 9""",170 lbs.,"72""",Orthodox,"Jul 14, 1987",http://ufcstats.com/fighter-details/a2b12c3f3d60ff69
 Nick Garcia,"5' 4""",125 lbs.,--,,--,http://ufcstats.com/fighter-details/8a04d94dfcfab159
-Steve Garcia,"6' 0""",155 lbs.,"75""",Southpaw,"May 22, 1992",http://ufcstats.com/fighter-details/97cf1a2c7c5e7889
+Steve Garcia,"6' 0""",145 lbs.,"75""",Southpaw,"May 22, 1992",http://ufcstats.com/fighter-details/97cf1a2c7c5e7889
 Elias Garcia,"5' 5""",125 lbs.,"67""",Southpaw,"Sep 13, 1992",http://ufcstats.com/fighter-details/ac5a7400da3a9a41
 Rafa Garcia,"5' 7""",155 lbs.,"70""",Orthodox,"Aug 05, 1994",http://ufcstats.com/fighter-details/e132d47bd9efbbe0
 Fernie Garcia,"5' 7""",135 lbs.,"67""",Orthodox,"Apr 12, 1992",http://ufcstats.com/fighter-details/9e92e1ca498d7244
 Rulon Gardner,"6' 3""",265 lbs.,--,Orthodox,"Aug 16, 1971",http://ufcstats.com/fighter-details/4f7e290e71d60f87
 David Gardner,"5' 11""",155 lbs.,--,Orthodox,"May 17, 1977",http://ufcstats.com/fighter-details/70167689d6a01793
-Ian Garry,"6' 3""",170 lbs.,"74""",Orthodox,"Nov 17, 1997",http://ufcstats.com/fighter-details/442c9011034ae1fd
 Pablo Garza,"6' 1""",145 lbs.,"73""",Orthodox,"Sep 16, 1983",http://ufcstats.com/fighter-details/8e5bfd4e82352340
 Azamat Gashimov,"5' 6""",125 lbs.,--,Orthodox,"Apr 07, 1990",http://ufcstats.com/fighter-details/a1b0715c4fd2dbd3
 Brian Gassaway,"6' 1""",170 lbs.,--,Orthodox,"Aug 07, 1972",http://ufcstats.com/fighter-details/e4770d5ed44a3970
-Kelvin Gastelum,"5' 9""",185 lbs.,"71""",Southpaw,"Oct 24, 1991",http://ufcstats.com/fighter-details/8c0580d4fff106c1
+Kelvin Gastelum,"5' 9""",170 lbs.,"71""",Southpaw,"Oct 24, 1991",http://ufcstats.com/fighter-details/8c0580d4fff106c1
 Willie Gates,"5' 8""",125 lbs.,"72""",Orthodox,"Jan 21, 1987",http://ufcstats.com/fighter-details/6ded9184b2284645
-Melissa Gatto,"5' 5""",125 lbs.,"69""",Orthodox,"Feb 05, 1996",http://ufcstats.com/fighter-details/a4a80dd7336ffd59
+Melissa Gatto,"5' 5""",135 lbs.,"69""",Orthodox,"May 02, 1996",http://ufcstats.com/fighter-details/a4a80dd7336ffd59
+Sean Gauci,"5' 5""",125 lbs.,"64""",Switch,"Oct 07, 1996",http://ufcstats.com/fighter-details/d758f272d94f5866
 Louis Gaudinot,"5' 3""",125 lbs.,"63""",Orthodox,"Aug 28, 1984",http://ufcstats.com/fighter-details/b72a60a0cadff408
+Ateba Gautier,"6' 4""",185 lbs.,"81""",Switch,"Apr 10, 2002",http://ufcstats.com/fighter-details/2f815ed5f8278ba6
 Manuel Gaxhja,"5' 8""",155 lbs.,--,Switch,"Jul 23, 1997",http://ufcstats.com/fighter-details/618643d0d5c0631d
+Shamil Gaziev,"6' 4""",265 lbs.,"78""",Orthodox,"Feb 10, 1990",http://ufcstats.com/fighter-details/6747ccd6d1acd266
 Charlene Gellner,"5' 2""",125 lbs.,--,,--,http://ufcstats.com/fighter-details/effd0b70e6749ab2
 Chad George,"5' 6""",135 lbs.,"68""",Southpaw,"Apr 30, 1982",http://ufcstats.com/fighter-details/14e797332ea32cdb
 Paul Georgieff,"6' 2""",170 lbs.,--,Orthodox,"Sep 22, 1982",http://ufcstats.com/fighter-details/2f1700b3a4a09bc7
 Brian Geraghty,"5' 7""",155 lbs.,--,Orthodox,"Nov 04, 1980",http://ufcstats.com/fighter-details/15edcf67ccf5be84
 Derek Getzel,"6' 0""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/42883268854b78be
 Karine Gevorgyan,"5' 4""",125 lbs.,"63""",,"Mar 09, 1989",http://ufcstats.com/fighter-details/2db0c114414d4f06
+Yanis Ghemmouri,"5' 9""",135 lbs.,"69""",Orthodox,"Jan 24, 1995",http://ufcstats.com/fighter-details/eb70e786bbdf1d16
 Darrel Gholar,"5' 8""",194 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/a24e080000fa7a35
 Tiki Ghosn,"5' 10""",170 lbs.,--,Orthodox,"Feb 09, 1977",http://ufcstats.com/fighter-details/cb6783c39c01d896
 Christos Giagos,"5' 10""",155 lbs.,"71""",Orthodox,"Jan 23, 1990",http://ufcstats.com/fighter-details/de45aaae23dfa392
@@ -1147,7 +1317,7 @@ Kenny Giddens,"5' 11""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/db8b
 Thomas Gifford,"6' 1""",155 lbs.,"75""",Orthodox,"Jul 26, 1992",http://ufcstats.com/fighter-details/e7f51d9f9e9259e7
 Joseph Gigliotti,"5' 11""",185 lbs.,--,Orthodox,"Aug 13, 1993",http://ufcstats.com/fighter-details/83825fad27ab3581
 Joey Gilbert,"5' 11""",155 lbs.,--,Orthodox,"Jun 05, 1976",http://ufcstats.com/fighter-details/6bb1d2b714d4b3bc
-Trevin Giles,"6' 0""",185 lbs.,"74""",Orthodox,"Aug 06, 1992",http://ufcstats.com/fighter-details/b27a1fcb56a3035a
+Trevin Giles,"6' 0""",170 lbs.,"74""",Orthodox,"Aug 06, 1992",http://ufcstats.com/fighter-details/b27a1fcb56a3035a
 Kultar Gill,"6' 0""",154 lbs.,--,Orthodox,"Mar 24, 1979",http://ufcstats.com/fighter-details/42c96a9c4802e2e1
 Jesse Gillespie,--,185 lbs.,--,,--,http://ufcstats.com/fighter-details/160b931119c1bf91
 Gregor Gillespie,"5' 7""",155 lbs.,"71""",Orthodox,"Nov 13, 1986",http://ufcstats.com/fighter-details/84ff027394f7e470
@@ -1156,6 +1326,7 @@ Micheal Gillmore,"5' 11""",170 lbs.,"72""",Orthodox,"Mar 28, 1987",http://ufcsta
 Krishaun Gilmore,--,--,--,,--,http://ufcstats.com/fighter-details/10ccdcd14c3dfcf1
 Alex Gilpin,"5' 7""",145 lbs.,--,Orthodox,"Mar 26, 1992",http://ufcstats.com/fighter-details/762c69860eef65d8
 Bob Gilstrap,"6' 3""",200 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/c96518b7f6881004
+Eperaim Ginting,"5' 4""",135 lbs.,"64""",Orthodox,"Nov 30, 1995",http://ufcstats.com/fighter-details/bad8ed7d714f1493
 Demetrius Gioulacos,"5' 11""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/a58114c6dd0add64
 Billy Giovanella,"5' 8""",125 lbs.,--,,"Aug 20, 1985",http://ufcstats.com/fighter-details/c1ea31a904fe08a9
 He-Man Gipson,--,--,--,,--,http://ufcstats.com/fighter-details/3e03cec9767d37e6
@@ -1163,15 +1334,18 @@ Israel Giron,"5' 8""",155 lbs.,--,,"Jan 16, 1974",http://ufcstats.com/fighter-de
 Brandon Girtz,"5' 7""",155 lbs.,--,,"Mar 06, 1985",http://ufcstats.com/fighter-details/81f1810f72df8f25
 Jason Glaza,"6' 0""",230 lbs.,--,,--,http://ufcstats.com/fighter-details/fda067e842b07466
 Mike Glenn,--,205 lbs.,--,,"Oct 09, 1977",http://ufcstats.com/fighter-details/ed133185689088b3
-Ricky Glenn,"6' 0""",155 lbs.,"70""",Southpaw,"Apr 12, 1989",http://ufcstats.com/fighter-details/814ff3018127e8fc
+Ricky Glenn,"6' 0""",170 lbs.,"70""",Southpaw,"Apr 12, 1989",http://ufcstats.com/fighter-details/814ff3018127e8fc
 Mark Godbeer,"6' 4""",240 lbs.,"77""",Orthodox,"Nov 22, 1983",http://ufcstats.com/fighter-details/ad56b3f00ca38dfd
 Clint Godfrey,"5' 6""",135 lbs.,--,Southpaw,"Oct 21, 1982",http://ufcstats.com/fighter-details/bd85ca0bb4f26cfc
 Loopy Godinez,"5' 2""",115 lbs.,"61""",Orthodox,"Sep 06, 1993",http://ufcstats.com/fighter-details/8e5d953bdb9ae5e7
 Jason Godsey,"6' 2""",230 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/5ca158b1cc9cb242
 Allan Goes,"6' 0""",205 lbs.,--,Orthodox,"Apr 20, 1971",http://ufcstats.com/fighter-details/e62b36885ecdac27
+Billy Ray Goff,"5' 10""",170 lbs.,"72""",Switch,"Jun 18, 1998",http://ufcstats.com/fighter-details/fa07345cc9db5cc9
+Amiran Gogoladze,"6' 1""",170 lbs.,"74""",Switch,"Dec 09, 1997",http://ufcstats.com/fighter-details/5d1636b6c1688502
 Jonny Goh,"5' 11""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/e86af30738a5452a
 Hannah Goldy,"5' 4""",115 lbs.,"61""",Orthodox,"May 18, 1992",http://ufcstats.com/fighter-details/26e3f3928b1891d9
 Marcelo Golm,"6' 3""",249 lbs.,"75""",Orthodox,"Sep 15, 1992",http://ufcstats.com/fighter-details/ac29d508d78384c9
+Denise Gomes,"5' 2""",115 lbs.,"63""",Orthodox,"Dec 30, 1999",http://ufcstats.com/fighter-details/cffb87059e645bd1
 Sergio Gomez,"5' 6""",155 lbs.,--,Orthodox,"Apr 29, 1982",http://ufcstats.com/fighter-details/af1e5c64b8663aa0
 Frank Gomez,"5' 10""",135 lbs.,"67""",Orthodox,"Mar 31, 1986",http://ufcstats.com/fighter-details/a0a680fe2f6cc8e6
 Alan Gomez,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/0a66de3a797cf73a
@@ -1183,6 +1357,7 @@ Joey Gomez,"5' 10""",155 lbs.,"71""",Orthodox,"Aug 29, 1989",http://ufcstats.com
 Edson Gomez,"5' 8""",170 lbs.,"69""",Switch,"Feb 23, 1991",http://ufcstats.com/fighter-details/e90f4291f93708e6
 Silvana Gomez Juarez,"5' 3""",115 lbs.,"65""",Orthodox,"Dec 06, 1984",http://ufcstats.com/fighter-details/b4880ef2f838d4e1
 Takanori Gomi,"5' 7""",155 lbs.,"70""",Southpaw,"Sep 22, 1978",http://ufcstats.com/fighter-details/3be081c29bf734d9
+William Gomis,"6' 0""",145 lbs.,"73""",Southpaw,"Jun 13, 1997",http://ufcstats.com/fighter-details/e1d40e8782d80bc2
 Akihiro Gono,"5' 7""",170 lbs.,"68""",Switch,"Oct 07, 1974",http://ufcstats.com/fighter-details/b2acebbef8da14ea
 Gabriel Gonzaga,"6' 2""",242 lbs.,"76""",Orthodox,"May 18, 1979",http://ufcstats.com/fighter-details/270b89c00ef0c55c
 Justin Gonzales,"5' 9""",145 lbs.,"72""",Orthodox,"Apr 28, 1991",http://ufcstats.com/fighter-details/94535f76f43b466a
@@ -1203,11 +1378,12 @@ Gary Goodridge,"6' 3""",249 lbs.,--,Orthodox,"Jan 17, 1966",http://ufcstats.com/
 Jordan Goodwin,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/7f98d9d5a10fa25c
 Gerard Gordeau,"6' 5""",216 lbs.,--,Orthodox,"Mar 30, 1959",http://ufcstats.com/fighter-details/279093302a6f44b3
 Eddie Gordon,"6' 0""",185 lbs.,"76""",Orthodox,"Jul 22, 1983",http://ufcstats.com/fighter-details/8cad40a75e5c97f5
-Jared Gordon,"5' 9""",145 lbs.,"68""",Orthodox,"Sep 06, 1988",http://ufcstats.com/fighter-details/7026eca45f65377b
+Jared Gordon,"5' 9""",155 lbs.,"68""",Orthodox,"Sep 06, 1988",http://ufcstats.com/fighter-details/7026eca45f65377b
 Tebaris Gordon,"6' 1""",265 lbs.,--,Orthodox,"Jul 19, 1988",http://ufcstats.com/fighter-details/68c4ca70067bf282
 Malcolm Gordon,"5' 7""",125 lbs.,"71""",Switch,"May 19, 1990",http://ufcstats.com/fighter-details/dee294e9717012c2
 Tresean Gore,"6' 0""",185 lbs.,"75""",Switch,"Jun 21, 1994",http://ufcstats.com/fighter-details/147e70aa6cc48cfc
 Alex Gorgees,"6' 2""",155 lbs.,"74""",Switch,"Aug 11, 1995",http://ufcstats.com/fighter-details/803bebcfb6d6f506
+Themba Gorimbo,"6' 1""",170 lbs.,"77""",Orthodox,"Jan 23, 1991",http://ufcstats.com/fighter-details/40f3cb27fc7305a1
 Tim Gorman,"5' 5""",135 lbs.,--,Southpaw,"Apr 29, 1983",http://ufcstats.com/fighter-details/c10eb2f12c489f6d
 Chase Gormley,"6' 3""",265 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/052ceb8976695342
 Jonathan Goulet,"6' 0""",170 lbs.,"73""",Orthodox,"Jul 13, 1979",http://ufcstats.com/fighter-details/fb1538b46877a695
@@ -1217,6 +1393,7 @@ Todd Gouwenberg,"6' 1""",205 lbs.,--,Orthodox,"Sep 25, 1974",http://ufcstats.com
 Hugo Govea,--,--,--,,--,http://ufcstats.com/fighter-details/2391a73686200c5d
 Justin Governale,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/ae954fd497025462
 Damian Grabowski,"6' 1""",241 lbs.,"75""",Orthodox,"May 12, 1980",http://ufcstats.com/fighter-details/3f11b5d4bd76a6d9
+Patryk Grabowski,--,205 lbs.,--,,"Nov 12, 1995",http://ufcstats.com/fighter-details/4e163b53d1de1fbc
 Royce Gracie,"6' 1""",175 lbs.,--,Southpaw,"Dec 12, 1966",http://ufcstats.com/fighter-details/429e7d3725852ce9
 Crosley Gracie,"5' 9""",190 lbs.,--,Orthodox,"Jul 18, 1979",http://ufcstats.com/fighter-details/52d92050a046bc17
 Daniel Gracie,"6' 2""",225 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/82d6a9ae41aac3f7
@@ -1233,12 +1410,13 @@ Roger Gracie,"6' 4""",185 lbs.,"79""",Orthodox,"Sep 26, 1981",http://ufcstats.co
 Igor Gracie,"5' 11""",170 lbs.,--,,"Feb 04, 1980",http://ufcstats.com/fighter-details/722b870449243083
 Neiman Gracie,"6' 0""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/12d855d12a624da2
 Kron Gracie,"5' 9""",145 lbs.,"70""",Southpaw,"Jul 11, 1988",http://ufcstats.com/fighter-details/242d36d241b43c12
+Bogdan Grad,"5' 8""",145 lbs.,"70""",Orthodox,"Sep 28, 1995",http://ufcstats.com/fighter-details/fb37795db81f93f3
 Steven Graham,"6' 1""",290 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/3e514f437c51ce0a
 Scott Graham,"6' 4""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/6e4acc2c115215b5
-Miranda Granger,"5' 7""",125 lbs.,"68""",Orthodox,"Apr 13, 1992",http://ufcstats.com/fighter-details/7559395ad833c074
+Miranda Granger,"5' 7""",115 lbs.,"68""",Orthodox,"Apr 13, 1992",http://ufcstats.com/fighter-details/7559395ad833c074
 TJ Grant,"5' 10""",155 lbs.,"72""",Orthodox,"Feb 26, 1984",http://ufcstats.com/fighter-details/a26198ba5093147e
 Davey Grant,"5' 8""",135 lbs.,"69""",Orthodox,"Dec 18, 1985",http://ufcstats.com/fighter-details/113df4fde64735c6
-Dwight Grant,"6' 1""",170 lbs.,"76""",Switch,"Sep 14, 1984",http://ufcstats.com/fighter-details/8be158ca1e5ea6a0
+Dwight Grant,"6' 1""",185 lbs.,"76""",Switch,"Sep 14, 1984",http://ufcstats.com/fighter-details/8be158ca1e5ea6a0
 Alexa Grasso,"5' 5""",125 lbs.,"66""",Orthodox,"Aug 09, 1993",http://ufcstats.com/fighter-details/e8b731feff72294b
 Tony Gravely,"5' 5""",135 lbs.,"69""",Orthodox,"Sep 28, 1991",http://ufcstats.com/fighter-details/601964f9654f911a
 Michael Graves,"5' 10""",170 lbs.,"71""",Orthodox,"Jan 08, 1991",http://ufcstats.com/fighter-details/3f1d23b01c552a13
@@ -1246,9 +1424,9 @@ Shelton Graves,"6' 2""",255 lbs.,"76""",Southpaw,"Oct 23, 1985",http://ufcstats.
 James Gray,"5' 9""",135 lbs.,--,Orthodox,"Oct 25, 1987",http://ufcstats.com/fighter-details/2db65fc038c0018e
 Kevin Gray,"5' 4""",125 lbs.,"67""",Orthodox,"May 03, 1985",http://ufcstats.com/fighter-details/bb0d290026d7681d
 Sam Greco,"6' 2""",205 lbs.,--,Orthodox,"May 03, 1967",http://ufcstats.com/fighter-details/6d12031661db8ac8
-Bobby Green,"5' 10""",155 lbs.,"71""",Orthodox,"Sep 09, 1986",http://ufcstats.com/fighter-details/887961364be5ceb3
+King Green,"5' 10""",155 lbs.,"71""",Orthodox,"Sep 09, 1986",http://ufcstats.com/fighter-details/887961364be5ceb3
 Desmond Green,"5' 10""",155 lbs.,"73""",Southpaw,"Oct 11, 1989",http://ufcstats.com/fighter-details/f046d724d2a84ac5
-Gabe Green,"5' 10""",170 lbs.,"73""",Switch,"May 02, 1993",http://ufcstats.com/fighter-details/5eb50529a8418b77
+Gabe Green,"5' 10""",155 lbs.,"73""",Switch,"May 02, 1993",http://ufcstats.com/fighter-details/5eb50529a8418b77
 Maurice Greene,"6' 7""",258 lbs.,"80""",Orthodox,"Jul 05, 1986",http://ufcstats.com/fighter-details/068f8a189a47fea6
 Matt Grice,"5' 8""",145 lbs.,"70""",Orthodox,"Jul 29, 1981",http://ufcstats.com/fighter-details/bfc2fc38a0e20211
 Forrest Griffin,"6' 3""",205 lbs.,"77""",Orthodox,"Mar 16, 1979",http://ufcstats.com/fighter-details/fcffee71cff5530e
@@ -1256,6 +1434,7 @@ Tyson Griffin,"5' 6""",145 lbs.,"68""",Orthodox,"Apr 20, 1984",http://ufcstats.c
 Max Griffin,"5' 11""",170 lbs.,"76""",Orthodox,"Nov 29, 1985",http://ufcstats.com/fighter-details/b0d6a1d8ac3d563d
 Jordan Griffin,"5' 10""",145 lbs.,"73""",Southpaw,"Feb 28, 1990",http://ufcstats.com/fighter-details/ebef46976554f975
 Chad Griggs,"6' 1""",205 lbs.,"73""",Orthodox,"May 15, 1978",http://ufcstats.com/fighter-details/fdf18227faa596dd
+Charalampos Grigoriou,"5' 7""",135 lbs.,"67""",Orthodox,"Mar 31, 1992",http://ufcstats.com/fighter-details/68b8ebdfce9dbb61
 Chuck Grigsby,"6' 6""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/7fb4234670271505
 Rodrigo Gripp de Sousa,"5' 11""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/dde70a112e053a6c
 Maxim Grishin,"6' 3""",205 lbs.,"78""",Orthodox,"May 02, 1984",http://ufcstats.com/fighter-details/950d0ef5c17157c5
@@ -1269,6 +1448,7 @@ Mike Grundy,"5' 7""",145 lbs.,"72""",Orthodox,"Jan 03, 1987",http://ufcstats.com
 Wang Guan,"5' 9""",145 lbs.,"71""",Orthodox,"Mar 14, 1986",http://ufcstats.com/fighter-details/dd12382f28296f7b
 Nandor Guelmino,"6' 3""",230 lbs.,--,,"Dec 20, 1975",http://ufcstats.com/fighter-details/1abfb658cd4f8533
 Fabricio Guerreiro,"5' 10""",145 lbs.,--,,"Jul 24, 1990",http://ufcstats.com/fighter-details/2963369e327e1979
+Rainn Guerrero,"5' 6""",125 lbs.,"65""",Orthodox,"May 13, 1992",http://ufcstats.com/fighter-details/8300a47f6fd6fe4f
 Shannon Gugerty,"5' 10""",155 lbs.,"71""",Orthodox,"Dec 30, 1981",http://ufcstats.com/fighter-details/9f1641c08cf8fbe2
 Clay Guida,"5' 7""",155 lbs.,"70""",Orthodox,"Dec 08, 1981",http://ufcstats.com/fighter-details/c47df9303d318c67
 Jason Guida,"5' 10""",214 lbs.,--,,"Aug 04, 1977",http://ufcstats.com/fighter-details/ce25b4ed82b1811b
@@ -1281,17 +1461,24 @@ John Gunderson,"5' 9""",155 lbs.,"69""",Orthodox,"Jan 05, 1979",http://ufcstats.
 John Gunther,"5' 9""",155 lbs.,"72""",Orthodox,"Nov 24, 1985",http://ufcstats.com/fighter-details/3956bdc8ab2e54b3
 Jorge Gurgel,"5' 7""",155 lbs.,"69""",Orthodox,"Jan 25, 1977",http://ufcstats.com/fighter-details/04d5718ed2661e8c
 Fabio Gurgel,"6' 0""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/8377c5572cb356f3
+Luis Gurule,"5' 5""",125 lbs.,"64""",Orthodox,"Nov 16, 1993",http://ufcstats.com/fighter-details/29162be25ebef5f0
+Bogdan Guskov,"6' 3""",205 lbs.,"76""",Orthodox,"Sep 12, 1992",http://ufcstats.com/fighter-details/ef5dcb10d2bd4b0f
+Gugun Gusman,"5' 7""",135 lbs.,"68""",Orthodox,"Mar 03, 1990",http://ufcstats.com/fighter-details/e34e3b1fffa13a6a
 Andre Gusmao,"6' 0""",205 lbs.,--,Orthodox,"May 19, 1977",http://ufcstats.com/fighter-details/cc300e9aa3063431
 Alexander Gustafsson,"6' 5""",205 lbs.,"79""",Orthodox,"Jan 15, 1987",http://ufcstats.com/fighter-details/3c6976f8182d9527
+Andreas Gustafsson,"6' 1""",170 lbs.,"73""",Orthodox,"Feb 20, 1991",http://ufcstats.com/fighter-details/2caf993f53541fa1
 Justin Guthrie,"6' 1""",170 lbs.,--,,"Jan 19, 1981",http://ufcstats.com/fighter-details/a789defa9086da46
 Horacio Gutierrez,"5' 10""",145 lbs.,--,,"Sep 15, 1990",http://ufcstats.com/fighter-details/cd85b48dc880fabd
-Chris Gutierrez,"5' 9""",145 lbs.,"67""",Orthodox,"Apr 22, 1991",http://ufcstats.com/fighter-details/45f0cc9d18f35137
+Chris Gutierrez,"5' 9""",135 lbs.,"67""",Orthodox,"Apr 22, 1991",http://ufcstats.com/fighter-details/45f0cc9d18f35137
+Mando Gutierrez,"5' 6""",135 lbs.,"70""",Southpaw,"Feb 24, 1997",http://ufcstats.com/fighter-details/5f33ae0620e050c5
 Mike Guymon,"6' 0""",170 lbs.,"74""",Orthodox,"Sep 17, 1974",http://ufcstats.com/fighter-details/eaea0fc7b76525a8
 Chelsea Hackett,"5' 4""",125 lbs.,"66""",Switch,"Aug 16, 1998",http://ufcstats.com/fighter-details/184b7a36d50dcc5e
 Keith Hackney,"5' 11""",200 lbs.,--,Sideways,--,http://ufcstats.com/fighter-details/bf12aca029bfcc47
-Jake Hadley,"5' 7""",125 lbs.,"70""",Southpaw,"Aug 03, 1996",http://ufcstats.com/fighter-details/60a42bf82447c919
+Cody Haddon,"5' 7""",135 lbs.,"69""",Orthodox,"Sep 08, 1998",http://ufcstats.com/fighter-details/8e6654e9f0461b8f
+Jake Hadley,"5' 7""",135 lbs.,"70""",Southpaw,"Aug 03, 1996",http://ufcstats.com/fighter-details/60a42bf82447c919
 Steve Hadsel,"5' 8""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/99793cf88c5adeee
 Damir Hadzovic,"5' 9""",155 lbs.,"70""",Orthodox,"Aug 08, 1986",http://ufcstats.com/fighter-details/38c626ca912c7bac
+Bassil Hafez,"5' 11""",170 lbs.,"72""",Orthodox,"Jan 31, 1992",http://ufcstats.com/fighter-details/f4d92416da98804b
 Tim Hague,"6' 4""",260 lbs.,"76""",Orthodox,"May 09, 1983",http://ufcstats.com/fighter-details/219a254e15d60135
 Yazan Hajeh,"5' 9""",145 lbs.,--,Orthodox,"Sep 04, 1992",http://ufcstats.com/fighter-details/4955c524c2a71469
 Stoney Hale,"6' 0""",--,--,,"Oct 18, 1979",http://ufcstats.com/fighter-details/206a7d47eb62170e
@@ -1307,6 +1494,7 @@ John Halverson,"5' 9""",155 lbs.,--,Southpaw,"Sep 08, 1972",http://ufcstats.com/
 Seo Hee Ham,"5' 2""",115 lbs.,"62""",Southpaw,"Mar 08, 1987",http://ufcstats.com/fighter-details/165c244bcca3ed26
 Frank Hamaker,--,--,--,,--,http://ufcstats.com/fighter-details/c3c23c99477c041b
 Kazuhiro Hamanaka,"6' 0""",185 lbs.,--,Southpaw,"Oct 24, 1978",http://ufcstats.com/fighter-details/1b4d6971bb18b82c
+Rami Hamed,"6' 1""",170 lbs.,"71""",Orthodox,"Apr 25, 1991",http://ufcstats.com/fighter-details/a59017211b775b5d
 Matt Hamill,"6' 1""",205 lbs.,"76""",Orthodox,"Oct 05, 1976",http://ufcstats.com/fighter-details/98b80a717b9bda17
 Jeremy Hamilton,--,185 lbs.,--,,"Nov 14, 1984",http://ufcstats.com/fighter-details/7ada6ea792a34424
 Anthony Hamilton,"6' 5""",260 lbs.,"76""",Orthodox,"Apr 14, 1980",http://ufcstats.com/fighter-details/c727c7d31c50c4cf
@@ -1314,15 +1502,21 @@ CJ Hamilton,"5' 7""",125 lbs.,"68""",Switch,"Oct 07, 1986",http://ufcstats.com/f
 Jared Hamman,"6' 3""",185 lbs.,"75""",Orthodox,"Mar 07, 1982",http://ufcstats.com/fighter-details/23459ee7e373b98f
 James Hammortree,"6' 3""",185 lbs.,--,Orthodox,"Nov 29, 1983",http://ufcstats.com/fighter-details/1f77fce698e80488
 Dean Hancock,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/24e9d6b0a24cff9d
+Chad Hanekom,"6' 4""",185 lbs.,"74""",Orthodox,"Apr 20, 1990",http://ufcstats.com/fighter-details/98533a2738124a0d
 Joachim Hansen,"5' 7""",150 lbs.,--,Southpaw,"May 26, 1979",http://ufcstats.com/fighter-details/86e388ed20761ad9
 Kay Hansen,"5' 2""",115 lbs.,"63""",Orthodox,"Aug 14, 1999",http://ufcstats.com/fighter-details/4100c7a09497ad41
 Nasrat Haqparast,"5' 10""",155 lbs.,"72""",Southpaw,"Aug 22, 1995",http://ufcstats.com/fighter-details/b7b84ccd221be298
+Shin Haraguchi,"5' 5""",145 lbs.,"68""",Switch,"Nov 27, 1998",http://ufcstats.com/fighter-details/05b17ae24e6bba81
 Janay Harding,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/b9c3ee342eb72100
 Antoni Hardonk,"6' 4""",245 lbs.,"78""",Orthodox,"Feb 05, 1976",http://ufcstats.com/fighter-details/69b69c0178c4004d
+George Hardwick,"5' 10""",155 lbs.,"72""",Orthodox,"Dec 06, 1996",http://ufcstats.com/fighter-details/f55a6807b6bb853d
 Dan Hardy,"6' 0""",170 lbs.,"74""",Orthodox,"May 17, 1982",http://ufcstats.com/fighter-details/473ce3aa581251a2
+Veronica Hardy,"5' 4""",125 lbs.,"64""",Southpaw,"Oct 30, 1995",http://ufcstats.com/fighter-details/4798e823ada58fe9
 Greg Hardy,"6' 5""",265 lbs.,"80""",Orthodox,"Jul 28, 1988",http://ufcstats.com/fighter-details/85073dbd1be65ed9
+Tobias Harila,--,--,--,,"Jan 13, 1994",http://ufcstats.com/fighter-details/4d1e92b61bcef308
 Baru Harn,--,265 lbs.,--,,--,http://ufcstats.com/fighter-details/848809f3986b4977
 Scott Harper,"6' 0""",185 lbs.,--,Orthodox,"Apr 14, 1972",http://ufcstats.com/fighter-details/14a433bccba87016
+Josiah Harrell,"5' 7""",170 lbs.,"68""",Southpaw,"Nov 13, 1998",http://ufcstats.com/fighter-details/e5864a42c80294f6
 Gerry Harris,"6' 8""",270 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/30cd319d39ee689b
 Gerald Harris,"5' 11""",185 lbs.,"77""",Southpaw,"Nov 19, 1979",http://ufcstats.com/fighter-details/c4b81cdecd5d6abe
 Phil Harris,"5' 4""",125 lbs.,"65""",Orthodox,"Sep 04, 1983",http://ufcstats.com/fighter-details/ba043b03eb799063
@@ -1330,7 +1524,9 @@ Walt Harris,"6' 5""",250 lbs.,"77""",Southpaw,"Jun 10, 1983",http://ufcstats.com
 Dhafir Harris,--,257 lbs.,--,,"Aug 04, 1977",http://ufcstats.com/fighter-details/0e96af5220d27ed4
 Trevor Harris,"5' 6""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/0e98b05d3cf6d271
 Carlston Harris,"6' 0""",170 lbs.,"76""",Orthodox,"Jul 09, 1987",http://ufcstats.com/fighter-details/a53d30163304aa6e
+Kayla Harrison,"5' 8""",135 lbs.,"66""",Southpaw,"Jul 02, 1990",http://ufcstats.com/fighter-details/1af1170ed937cba7
 Collin Hart,"6' 1""",185 lbs.,--,Orthodox,"Oct 12, 1989",http://ufcstats.com/fighter-details/16bf6a73bdd302cd
+Joey Hart,"6' 3""",170 lbs.,"79""",Orthodox,"Jun 24, 1997",http://ufcstats.com/fighter-details/6412da484125716b
 Dale Hartt,"5' 10""",155 lbs.,"69""",Orthodox,"Apr 04, 1979",http://ufcstats.com/fighter-details/058e4e08a1ad8aba
 Luke Hartwig,--,--,--,,--,http://ufcstats.com/fighter-details/34f3869747bf8fa9
 Clay Harvison,"6' 1""",170 lbs.,"74""",Orthodox,"Sep 25, 1980",http://ufcstats.com/fighter-details/83a477a7dba1ca58
@@ -1340,6 +1536,7 @@ Takayo Hashi,"5' 4""",135 lbs.,--,Orthodox,"Oct 02, 1977",http://ufcstats.com/fi
 Tomohiko Hashimoto,"6' 0""",250 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/a890f9a791ed615d
 Justin Haskins,"5' 10""",170 lbs.,--,Orthodox,"Aug 30, 1979",http://ufcstats.com/fighter-details/77940e45bc86208e
 Hayder Hassan,"5' 10""",170 lbs.,--,,"Oct 20, 1982",http://ufcstats.com/fighter-details/cf615eb4b7862c76
+Ahmad Hassanzada,"6' 1""",155 lbs.,"75""",Orthodox,"Nov 20, 1996",http://ufcstats.com/fighter-details/bf7a64d9ae343e86
 Daiki Hata,"5' 6""",139 lbs.,--,Orthodox,"Aug 24, 1982",http://ufcstats.com/fighter-details/c76ceda100ac0fad
 John Hathaway,"6' 1""",170 lbs.,"75""",Orthodox,"Jul 23, 1987",http://ufcstats.com/fighter-details/28f3c2258a1d8874
 Phil Hawes,"6' 0""",185 lbs.,"77""",Orthodox,"Jan 08, 1989",http://ufcstats.com/fighter-details/547afe1017e72dbe
@@ -1370,8 +1567,9 @@ Benson Henderson,"5' 9""",170 lbs.,"70""",Southpaw,"Nov 16, 1983",http://ufcstat
 Ron Henderson,"5' 10""",125 lbs.,--,,--,http://ufcstats.com/fighter-details/498f0d066396ec59
 Josh Hendricks,"6' 2""",235 lbs.,--,Southpaw,"Aug 28, 1976",http://ufcstats.com/fighter-details/7649c4c95b824488
 Johny Hendricks,"5' 9""",185 lbs.,"69""",Southpaw,"Sep 12, 1983",http://ufcstats.com/fighter-details/0941df56f6ac954b
-Cory Hendricks,"6' 3""",205 lbs.,--,,"May 10, 1988",http://ufcstats.com/fighter-details/9ab9912e0f8fa6d6
+Cory Hendricks,"6' 3""",205 lbs.,--,Switch,"May 10, 1988",http://ufcstats.com/fighter-details/9ab9912e0f8fa6d6
 Luis Henrique,"6' 2""",243 lbs.,"74""",Orthodox,"Aug 21, 1993",http://ufcstats.com/fighter-details/e5bda12faabfc850
+Jose Henrique,"6' 3""",170 lbs.,"79""",Orthodox,"May 23, 2002",http://ufcstats.com/fighter-details/20a0e4cc5227c117
 Diego Henrique da Silva,"6' 2""",185 lbs.,--,Orthodox,"Aug 22, 1986",http://ufcstats.com/fighter-details/1649770c649db6a5
 Danny Henry,"6' 0""",145 lbs.,"73""",Orthodox,"Jul 17, 1988",http://ufcstats.com/fighter-details/f7d73e452b064bf2
 Victor Henry,"5' 7""",135 lbs.,"68""",Switch,"May 04, 1987",http://ufcstats.com/fighter-details/eb8d8c2a95cfccb8
@@ -1387,6 +1585,7 @@ Alexander Hernandez,"5' 9""",155 lbs.,"72""",Orthodox,"Oct 01, 1992",http://ufcs
 Anthony Hernandez,"6' 0""",185 lbs.,"75""",Orthodox,"Oct 18, 1993",http://ufcstats.com/fighter-details/093e1f5bb73850be
 Nohelin Hernandez,"5' 10""",135 lbs.,"71""",Orthodox,"Mar 01, 1994",http://ufcstats.com/fighter-details/f97c5433c77522d3
 Carlos Hernandez,"5' 8""",125 lbs.,"67""",Orthodox,"Oct 25, 1993",http://ufcstats.com/fighter-details/798e48f9e7f6ba22
+Leslie Hernandez,"5' 3""",115 lbs.,"64""",Orthodox,"Dec 29, 1997",http://ufcstats.com/fighter-details/fc8610cc15674ae2
 Paul Herrera,"5' 10""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/440c9dbab63528fb
 Chris Herrera,"5' 10""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/f71028a6e5128856
 Geane Herrera,"5' 5""",125 lbs.,"66""",Orthodox,"May 27, 1990",http://ufcstats.com/fighter-details/c169545ab0825f44
@@ -1417,9 +1616,11 @@ Alan Hiro,"5' 5""",135 lbs.,--,Orthodox,"Apr 04, 1986",http://ufcstats.com/fight
 Kuniyoshi Hironaka,"5' 10""",168 lbs.,"70""",Orthodox,"Jun 17, 1976",http://ufcstats.com/fighter-details/9d4522df6fc49a47
 Mizuto Hirota,"5' 7""",155 lbs.,"67""",Orthodox,"May 05, 1981",http://ufcstats.com/fighter-details/35faad160d346839
 Yuji Hisamatsu,"5' 10""",185 lbs.,--,,"Sep 18, 1971",http://ufcstats.com/fighter-details/8332a607df696345
+An Tuan Ho,"5' 6""",125 lbs.,"66""",Switch,"Sep 27, 2000",http://ufcstats.com/fighter-details/6c9384138c82962f
 Kwan Ho Kwak,"5' 5""",135 lbs.,--,Switch,"Jun 18, 1989",http://ufcstats.com/fighter-details/c13042265355a290
 Matt Hobar,"5' 10""",135 lbs.,"70""",Southpaw,"Jan 07, 1987",http://ufcstats.com/fighter-details/b57edace7b647f07
 Bobby Hoffman,"6' 2""",245 lbs.,--,Orthodox,"Oct 28, 1968",http://ufcstats.com/fighter-details/afaad7d6a581e307
+Chris Hofmann,"6' 0""",170 lbs.,"72""",Orthodox,"Nov 18, 1989",http://ufcstats.com/fighter-details/33fb306278dbb3e5
 Sam Hoger,"6' 2""",205 lbs.,--,Orthodox,"Jun 28, 1980",http://ufcstats.com/fighter-details/84a067c46306a737
 Andrew Holbrook,"5' 11""",155 lbs.,"70""",Southpaw,"Feb 06, 1986",http://ufcstats.com/fighter-details/66ab58d0b3783607
 Sean Holden,"5' 10""",170 lbs.,--,,"Sep 17, 1984",http://ufcstats.com/fighter-details/acbb9c76f5894e36
@@ -1441,19 +1642,22 @@ Sabah Homasi,"6' 0""",170 lbs.,"72""",Orthodox,"Oct 19, 1988",http://ufcstats.co
 Mark Hominick,"5' 8""",145 lbs.,"68""",Orthodox,"Jul 22, 1982",http://ufcstats.com/fighter-details/0a97691039c4bbfb
 Barb Honchak,"5' 4""",125 lbs.,"65""",Orthodox,"Aug 30, 1979",http://ufcstats.com/fighter-details/472f6f6e6d962f40
 Chris Honeycutt,"5' 10""",170 lbs.,"73""",,"Jul 25, 1988",http://ufcstats.com/fighter-details/4d2e3320d815f687
+JunYoung Hong,"5' 9""",145 lbs.,"69""",Orthodox,"Dec 18, 1990",http://ufcstats.com/fighter-details/b24666e26bd750a3
+SeongChan Hong,"5' 7""",155 lbs.,"69""",Orthodox,"Nov 28, 1989",http://ufcstats.com/fighter-details/10d4575f497face4
 Satoshi Honma,"6' 1""",205 lbs.,--,Orthodox,"May 19, 1968",http://ufcstats.com/fighter-details/d2b1c1317a39f6c6
 David Hood,"6' 0""",200 lbs.,--,,--,http://ufcstats.com/fighter-details/5af480a3b2e1726b
 Lorenzo Hood,"6' 3""",265 lbs.,"80""",Southpaw,"Mar 02, 1989",http://ufcstats.com/fighter-details/7f9abc4db2d05764
-Dan Hooker,"6' 0""",145 lbs.,"75""",Switch,"Feb 13, 1990",http://ufcstats.com/fighter-details/193b9d1858bc4df3
-Chase Hooper,"6' 1""",145 lbs.,"74""",Southpaw,"Sep 13, 1999",http://ufcstats.com/fighter-details/971246648e162f0d
+Dan Hooker,"6' 0""",155 lbs.,"75""",Switch,"Feb 13, 1990",http://ufcstats.com/fighter-details/193b9d1858bc4df3
+Chase Hooper,"6' 1""",155 lbs.,"74""",Southpaw,"Sep 13, 1999",http://ufcstats.com/fighter-details/971246648e162f0d
 Darrell Horcher,"5' 10""",155 lbs.,"70""",Southpaw,"Jul 28, 1987",http://ufcstats.com/fighter-details/18e8b7070228e728
 Moti Horenstein,"6' 4""",230 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/baf942f4bcb09894
 Yoshinori Horie,"5' 8""",145 lbs.,"70""",Orthodox,"May 10, 1995",http://ufcstats.com/fighter-details/3fa7688bfe48a493
 Kyoji Horiguchi,"5' 5""",125 lbs.,"66""",Orthodox,"Oct 12, 1990",http://ufcstats.com/fighter-details/98aa60cf58071fd6
+Yuma Horiuchi,"5' 6""",125 lbs.,"67""",Switch,"Sep 22, 1997",http://ufcstats.com/fighter-details/f6c1ce7cfd600662
 Jeremy Horn,"6' 1""",185 lbs.,"74""",Orthodox,"Aug 25, 1975",http://ufcstats.com/fighter-details/8d26912cd2aeb366
 Matt Horning,"5' 4""",125 lbs.,--,,--,http://ufcstats.com/fighter-details/21632ba272c0785a
 Chris Horodecki,"5' 9""",155 lbs.,"69""",Orthodox,"Sep 24, 1987",http://ufcstats.com/fighter-details/e29cf523ebd155c5
-Jamey-Lyn Horth,"5' 7""",125 lbs.,--,,"Mar 30, 1990",http://ufcstats.com/fighter-details/5c637af9472ae7cc
+Jamey-Lyn Horth,"5' 7""",125 lbs.,"66""",Orthodox,"Mar 30, 1990",http://ufcstats.com/fighter-details/5c637af9472ae7cc
 Matt Horwich,"6' 1""",185 lbs.,--,Orthodox,"Oct 02, 1978",http://ufcstats.com/fighter-details/049d698d773eb3e1
 John Hosman,"5' 10""",135 lbs.,--,Southpaw,"Nov 13, 1980",http://ufcstats.com/fighter-details/57591bbf1623574e
 Saeed Hosseini,--,--,--,,--,http://ufcstats.com/fighter-details/21f2974fd08085e3
@@ -1467,6 +1671,8 @@ Shane Howell,"5' 8""",125 lbs.,--,Orthodox,"Nov 28, 1983",http://ufcstats.com/fi
 Hu Yaozong,"6' 3""",185 lbs.,"72""",Orthodox,"Apr 07, 1995",http://ufcstats.com/fighter-details/f1175ea3aafbf351
 Carlos Huachin,"5' 4""",135 lbs.,"67""",Southpaw,"Jun 04, 1996",http://ufcstats.com/fighter-details/225def29ecfe0fc1
 Brady Huang,"5' 9""",135 lbs.,"69""",Orthodox,"Dec 16, 1992",http://ufcstats.com/fighter-details/1ec1b6a7a29ffc71
+Yuele Huang,--,145 lbs.,--,,"Jul 04, 2000",http://ufcstats.com/fighter-details/1c8b9f4d89b92e1b
+Huang Feier,"5' 5""",115 lbs.,"65""",Orthodox,"Mar 12, 1994",http://ufcstats.com/fighter-details/e71c75f533a30daa
 Austin Hubbard,"5' 10""",155 lbs.,"71""",Orthodox,"Dec 22, 1991",http://ufcstats.com/fighter-details/d2cd7a69cc55e7ed
 Collin Huckbody,"6' 3""",185 lbs.,"76""",Orthodox,"Sep 29, 1994",http://ufcstats.com/fighter-details/f372a848d250e006
 Alex Huddleston,"6' 7""",254 lbs.,--,,"Aug 11, 1986",http://ufcstats.com/fighter-details/8b9197746bd3e005
@@ -1476,15 +1682,18 @@ Matt Hughes,"5' 9""",170 lbs.,"73""",Switch,"Oct 13, 1973",http://ufcstats.com/f
 Mark Hughes,"5' 9""",205 lbs.,--,Southpaw,"Oct 13, 1973",http://ufcstats.com/fighter-details/d62bb4d84a7267ba
 Jeff Hughes,"6' 2""",250 lbs.,"77""",Orthodox,"May 17, 1988",http://ufcstats.com/fighter-details/6a11e325aa60ad02
 Sam Hughes,"5' 5""",115 lbs.,"64""",Orthodox,"Jun 28, 1992",http://ufcstats.com/fighter-details/e94085e821bd81de
+Victor Hugo,"5' 7""",135 lbs.,"71""",Orthodox,"Nov 22, 1992",http://ufcstats.com/fighter-details/f264ba50b007f39e
 David Hulett,"5' 10""",170 lbs.,--,,"Sep 07, 1980",http://ufcstats.com/fighter-details/b0718335e9868cfd
+Dominik Humburger,--,185 lbs.,--,,"Jan 03, 1996",http://ufcstats.com/fighter-details/e4cbc82c36e47299
 Bryan Humes,--,265 lbs.,--,,--,http://ufcstats.com/fighter-details/b9c75e7fc910f587
 Abongo Humphrey,"5' 11""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/cb1b4d237b0079e6
-Harry Hunsucker,"6' 2""",241 lbs.,"75""",Orthodox,"Jan 03, 1989",http://ufcstats.com/fighter-details/f703250471acaf96
+Harry Hunsucker,"6' 2""",205 lbs.,"75""",Orthodox,"Jan 03, 1989",http://ufcstats.com/fighter-details/f703250471acaf96
 Mark Hunt,"5' 10""",265 lbs.,"72""",Orthodox,"Mar 23, 1974",http://ufcstats.com/fighter-details/eef9b891edbd4604
 Alex Hunter,"5' 9""",226 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/baa5358456803df8
 Adam Hunter,"6' 1""",185 lbs.,--,Orthodox,"Oct 16, 1983",http://ufcstats.com/fighter-details/edc9eb3051f444fa
 Joe Hurley,"5' 8""",155 lbs.,--,,"Jun 24, 1978",http://ufcstats.com/fighter-details/21b54430c8eeb9cc
 Solomon Hutcherson,"5' 11""",185 lbs.,--,Southpaw,"Aug 31, 1972",http://ufcstats.com/fighter-details/155bfc7ed36622df
+Young Hwang,"5' 9""",135 lbs.,--,,"Sep 02, 1988",http://ufcstats.com/fighter-details/8588d14c4952b9fa
 Al Iaquinta,"5' 10""",155 lbs.,"70""",Orthodox,"Apr 30, 1987",http://ufcstats.com/fighter-details/59279a7c978f7da0
 Khadis Ibragimov,"6' 3""",205 lbs.,"78""",Orthodox,"May 21, 1995",http://ufcstats.com/fighter-details/c3218c810959d279
 Minoki Ichihara,"5' 7""",178 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/4565d435005319c0
@@ -1499,6 +1708,7 @@ Yusuke Imamura,"5' 8""",220 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-deta
 Masakazu Imanari,"5' 4""",139 lbs.,--,Southpaw,"Feb 10, 1976",http://ufcstats.com/fighter-details/a4dd5c9a75763295
 Nassourdine Imavov,"6' 3""",185 lbs.,"75""",Orthodox,"Mar 01, 1995",http://ufcstats.com/fighter-details/881bf86d4cba8578
 Brad Imes,"6' 7""",265 lbs.,--,Orthodox,"Mar 13, 1977",http://ufcstats.com/fighter-details/4908c5ee68a50ee5
+Michael Imperato,"5' 7""",135 lbs.,"66""",Switch,"Sep 01, 1989",http://ufcstats.com/fighter-details/59e52d56bab2b1ee
 Chris Indich,"5' 10""",170 lbs.,--,,"Apr 22, 1987",http://ufcstats.com/fighter-details/d5b7fac960e58920
 Chris Inman,--,--,--,,--,http://ufcstats.com/fighter-details/f0a381ba65d2a933
 Guto Inocente,"6' 3""",205 lbs.,--,Orthodox,"May 29, 1986",http://ufcstats.com/fighter-details/e7fe5315b1efeb92
@@ -1507,11 +1717,11 @@ Egan Inoue,"5' 9""",190 lbs.,--,Southpaw,"Jul 04, 1965",http://ufcstats.com/figh
 Katsuya Inoue,"5' 9""",168 lbs.,--,Southpaw,"Aug 10, 1979",http://ufcstats.com/fighter-details/b5882371e2a3900d
 Takeshi Inoue,"5' 8""",145 lbs.,--,,"Mar 18, 1980",http://ufcstats.com/fighter-details/a61a0cd2829e5d4e
 Naoki Inoue,"5' 9""",125 lbs.,"71""",Orthodox,"Jun 14, 1997",http://ufcstats.com/fighter-details/199eb7cf6ae90294
-Inoue Mizuki,"5' 3""",125 lbs.,"65""",Orthodox,"Aug 19, 1994",http://ufcstats.com/fighter-details/43a59ce3bb40449e
 Jorge Interiano,"6' 1""",205 lbs.,--,,--,http://ufcstats.com/fighter-details/1e75e6c9de99fa76
 Jason Ireland,"5' 9""",161 lbs.,--,Southpaw,"Dec 30, 1979",http://ufcstats.com/fighter-details/05a0556072931f01
 James Irvin,"6' 2""",205 lbs.,"75""",Orthodox,"Sep 12, 1978",http://ufcstats.com/fighter-details/a7f4d0902bb64092
 Eric Irvin,"5' 8""",155 lbs.,--,,"Jan 10, 1986",http://ufcstats.com/fighter-details/a47c2a6e24757932
+Issa Isakov,"5' 9""",155 lbs.,"70""",Orthodox,"Oct 22, 1989",http://ufcstats.com/fighter-details/e9095aeb36f2aeb8
 Mitsuhiro Ishida,"5' 6""",154 lbs.,--,Southpaw,"Dec 29, 1978",http://ufcstats.com/fighter-details/82f5c81f4e3c3eb5
 Teruto Ishihara,"5' 7""",135 lbs.,"69""",Southpaw,"Jul 23, 1991",http://ufcstats.com/fighter-details/88cd34d836b4ebcd
 Satoshi Ishii,"5' 11""",240 lbs.,--,Orthodox,"Dec 19, 1986",http://ufcstats.com/fighter-details/c8a49ff2acb6f3c5
@@ -1525,6 +1735,8 @@ Blagoy Ivanov,"5' 11""",250 lbs.,"73""",Southpaw,"Oct 09, 1986",http://ufcstats.
 Anthony Ivy,"6' 2""",185 lbs.,"74""",Orthodox,"Jan 23, 1990",http://ufcstats.com/fighter-details/3c5005b66696d790
 Tomomi Iwama,"5' 3""",155 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/ac5f67109accb482
 Tatsuya Iwasaki,"5' 9""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/243b07fc65ccbb16
+Taiga Iwasaki,"6' 1""",185 lbs.,"73""",Orthodox,"Jul 07, 1997",http://ufcstats.com/fighter-details/5b08af4fbc987f9c
+Saygid Izagakhmaev,--,170 lbs.,--,,"Sep 03, 1994",http://ufcstats.com/fighter-details/de26d906f2874dd4
 Yoislandy Izquierdo,"5' 11""",155 lbs.,--,Southpaw,"Jan 09, 1984",http://ufcstats.com/fighter-details/afc2a7ce0c763bd5
 Hiroshi Izumi,--,205 lbs.,--,Orthodox,"Jun 22, 1982",http://ufcstats.com/fighter-details/53e4e21f4c688801
 Yves Jabouin,"5' 7""",135 lbs.,"68""",Orthodox,"May 30, 1979",http://ufcstats.com/fighter-details/b4eeac608fc82f88
@@ -1532,12 +1744,13 @@ Kevin Jackson,"5' 10""",199 lbs.,--,Switch,--,http://ufcstats.com/fighter-detail
 Eugene Jackson,"5' 8""",185 lbs.,--,Orthodox,"Sep 23, 1966",http://ufcstats.com/fighter-details/ce783bf73b5131f9
 Quinton Jackson,"6' 1""",205 lbs.,"73""",Orthodox,"Jun 20, 1978",http://ufcstats.com/fighter-details/ffc088e64fab57e9
 Jeremy Jackson,"5' 10""",170 lbs.,--,Orthodox,"Sep 19, 1982",http://ufcstats.com/fighter-details/ad32471f01e7b1a5
-Damon Jackson,"5' 11""",145 lbs.,"71""",Switch,"Aug 08, 1988",http://ufcstats.com/fighter-details/29af297d9f1de0f8
+Damon Jackson,"5' 11""",155 lbs.,"71""",Switch,"Aug 08, 1988",http://ufcstats.com/fighter-details/29af297d9f1de0f8
 Kenyon Jackson,"6' 0""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/56c5132870a526d5
-Mike Jackson,"6' 2""",170 lbs.,--,Orthodox,"Mar 22, 1985",http://ufcstats.com/fighter-details/0641c21bec209472
+Mike Jackson,"6' 2""",170 lbs.,"74""",Orthodox,"Mar 22, 1985",http://ufcstats.com/fighter-details/0641c21bec209472
 Jason Jackson,"6' 1""",170 lbs.,"78""",Orthodox,"Oct 30, 1990",http://ufcstats.com/fighter-details/ca8da445dfa82d56
 Montel Jackson,"5' 10""",135 lbs.,"75""",Southpaw,"Apr 24, 1992",http://ufcstats.com/fighter-details/cc1a8b4b38b92c6d
 Eric Jacob,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/ba17afef01ed78b6
+Richard Jacobi,"6' 4""",260 lbs.,"75""",Orthodox,"Sep 28, 1993",http://ufcstats.com/fighter-details/46f557bd44da630e
 Dustin Jacoby,"6' 3""",205 lbs.,"76""",Orthodox,"Apr 04, 1988",http://ufcstats.com/fighter-details/e4277e87a789d687
 Justin James,"5' 10""",155 lbs.,--,Orthodox,"Nov 08, 1976",http://ufcstats.com/fighter-details/1ea8df62b3f8fea6
 Nate James,"6' 0""",185 lbs.,--,,"May 29, 1978",http://ufcstats.com/fighter-details/a34fecf2f4e5a317
@@ -1553,6 +1766,7 @@ Josh Jarvis,--,--,--,,--,http://ufcstats.com/fighter-details/32e8e0e8498f03c2
 Rony Jason,"5' 7""",145 lbs.,"73""",Orthodox,"Mar 21, 1984",http://ufcstats.com/fighter-details/b71ce838b01f2cad
 Jasmine Jasudavicius,"5' 7""",125 lbs.,"68""",Orthodox,"Mar 01, 1989",http://ufcstats.com/fighter-details/a9e260472d321361
 Louis Jauregui,"5' 7""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/0e8744ded08ee5fb
+Yazmin Jauregui,"5' 3""",115 lbs.,"64""",Orthodox,"Feb 28, 1999",http://ufcstats.com/fighter-details/40cb680ae1cd331f
 Justin Jaynes,"5' 7""",145 lbs.,"68""",Orthodox,"Aug 10, 1989",http://ufcstats.com/fighter-details/304a21d0595e1a08
 Joanna Jedrzejczyk,"5' 6""",115 lbs.,"65""",Orthodox,"Aug 18, 1987",http://ufcstats.com/fighter-details/3d6749c4267da18f
 Aaron Jeffery,"6' 2""",185 lbs.,"73""",Orthodox,"Nov 14, 1992",http://ufcstats.com/fighter-details/ccdcb20370be62a3
@@ -1560,15 +1774,19 @@ Trent Jenkins,"6' 2""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/02fc8
 Bubba Jenkins,"5' 7""",145 lbs.,--,,"Feb 05, 1988",http://ufcstats.com/fighter-details/5e841bb3752b6e86
 Adrienna Jenkins,"5' 8""",145 lbs.,--,,"Jul 22, 1981",http://ufcstats.com/fighter-details/dae85a6a83f53215
 Brandon Jenkins,"6' 0""",155 lbs.,"71""",Switch,"Sep 30, 1991",http://ufcstats.com/fighter-details/6a8928652fc01bee
+Jack Jenkins,"5' 7""",145 lbs.,"68""",Switch,"Nov 03, 1993",http://ufcstats.com/fighter-details/a9da3158dd2c2b5a
 Steve Jennum,"5' 10""",215 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/ad047e3073a775f3
 Ryan Jensen,"6' 1""",185 lbs.,"76""",Orthodox,"Sep 20, 1977",http://ufcstats.com/fighter-details/aae99701b21554e4
 Kyle Jensen,"5' 9""",170 lbs.,--,Orthodox,"Jul 20, 1979",http://ufcstats.com/fighter-details/aec273fcb765330d
 Chan-Mi Jeon,"5' 5""",115 lbs.,--,Orthodox,"Aug 28, 1997",http://ufcstats.com/fighter-details/24174a3f44ce8e03
 Maciej Jewtuszko,"6' 0""",155 lbs.,--,Southpaw,"Jan 31, 1981",http://ufcstats.com/fighter-details/6b5b9be990774f0e
 Ronald Jhun,"5' 11""",170 lbs.,--,Orthodox,"Sep 21, 1970",http://ufcstats.com/fighter-details/b9e871af730f826c
+Baergeng Jieleyisi,"5' 9""",135 lbs.,"70""",Orthodox,"Nov 24, 1995",http://ufcstats.com/fighter-details/8677e67a75d65b8e
 Gilbert Jimenez,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/59d36ddfcb27b7dc
 Art Jimmerson,"6' 1""",196 lbs.,--,Orthodox,"Aug 04, 1963",http://ufcstats.com/fighter-details/a5c53b3ddb31cc7d
 Ryan Jimmo,"6' 1""",205 lbs.,"73""",Orthodox,"Nov 27, 1981",http://ufcstats.com/fighter-details/bc3ec52ef70fc155
+Jinensibieke Asikeerbai,"5' 6""",155 lbs.,"69""",Orthodox,"Jul 10, 1988",http://ufcstats.com/fighter-details/4eccb78d628b2238
+Jiniushiyue,"5' 6""",125 lbs.,"68""",Southpaw,"Dec 09, 2000",http://ufcstats.com/fighter-details/c14a683dac2ebc4c
 Sung Bin Jo,"6' 0""",145 lbs.,"72""",Orthodox,"Jul 17, 1992",http://ufcstats.com/fighter-details/6e0e977beb909837
 Carls John De Tomas,"5' 5""",125 lbs.,"71""",Southpaw,"Aug 28, 1996",http://ufcstats.com/fighter-details/2a4200ead401a9ce
 Phil Johns,"5' 2""",170 lbs.,--,Southpaw,"Oct 22, 1968",http://ufcstats.com/fighter-details/a8fa0c4e95512806
@@ -1591,12 +1809,13 @@ Tony Johnson,"6' 1""",265 lbs.,--,,--,http://ufcstats.com/fighter-details/a45bab
 Jordan Johnson,"6' 2""",205 lbs.,"79""",Orthodox,"Nov 18, 1988",http://ufcstats.com/fighter-details/99bcdf5eac39898f
 Taylor Johnson,"6' 0""",185 lbs.,"74""",Switch,"Nov 09, 1990",http://ufcstats.com/fighter-details/552b09cbf13b6328
 Chad Johnson,"6' 2""",230 lbs.,"80""",Orthodox,"Jul 22, 1986",http://ufcstats.com/fighter-details/6ce9a012e4c6020c
-Jose Johnson,"6' 0""",135 lbs.,"72""",Orthodox,"May 25, 1995",http://ufcstats.com/fighter-details/84f727cf0166d6f2
+Jose Johnson,"6' 0""",125 lbs.,"71""",Orthodox,"May 20, 1995",http://ufcstats.com/fighter-details/84f727cf0166d6f2
+Charles Johnson,"5' 9""",125 lbs.,"70""",Switch,"Jan 10, 1991",http://ufcstats.com/fighter-details/814e5233e2acf2ee
 Brian Johnston,"6' 3""",230 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/1c3f5e85b59ec710
 Liana Jojua,"5' 4""",125 lbs.,"62""",Orthodox,"Mar 22, 1995",http://ufcstats.com/fighter-details/eebc23626e38f5dc
 Daniel Jolly,"6' 1""",205 lbs.,"75""",Orthodox,"Sep 03, 1984",http://ufcstats.com/fighter-details/eeabcd4dc6619129
 Paul Jones,"5' 9""",199 lbs.,--,Orthodox,"Jun 16, 1963",http://ufcstats.com/fighter-details/f341f9551ba744e2
-Jon Jones,"6' 4""",205 lbs.,"84""",Orthodox,"Jul 19, 1987",http://ufcstats.com/fighter-details/07f72a2a7591b409
+Jon Jones,"6' 4""",248 lbs.,"84""",Orthodox,"Jul 19, 1987",http://ufcstats.com/fighter-details/07f72a2a7591b409
 Nathan Jones,"6' 11""",345 lbs.,--,Orthodox,"Aug 21, 1970",http://ufcstats.com/fighter-details/f54fb3b9c4228142
 Marcus Jones,"6' 6""",265 lbs.,--,Orthodox,"Aug 15, 1973",http://ufcstats.com/fighter-details/8fa2b06572365321
 Carlton Jones,"6' 1""",225 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/f117c3e8c1aa7b9e
@@ -1612,6 +1831,8 @@ Jamelle Jones,"6' 0""",205 lbs.,"75""",Orthodox,"Jan 31, 1988",http://ufcstats.c
 Antonio Jones,"5' 11""",185 lbs.,--,Orthodox,"Apr 12, 1985",http://ufcstats.com/fighter-details/f1fd494586ab8d5f
 Trevin Jones,"5' 7""",135 lbs.,"70""",Southpaw,"Aug 04, 1990",http://ufcstats.com/fighter-details/ec23c1be628d8057
 Mason Jones,"5' 10""",155 lbs.,"74""",Orthodox,"Apr 26, 1995",http://ufcstats.com/fighter-details/f6ad6a1e4d600e0d
+Craig Jones,--,205 lbs.,--,,"Jul 17, 1991",http://ufcstats.com/fighter-details/e947b563eb744a21
+Jacobi Jones,"5' 9""",155 lbs.,"72""",Orthodox,"May 24, 1996",http://ufcstats.com/fighter-details/08b01ed84044c6bc
 Jocelyn Jones-Lybarger,"5' 7""",115 lbs.,"64""",Orthodox,"Oct 04, 1985",http://ufcstats.com/fighter-details/1a98c9dbb7fc3959
 Kevin Jordan,"6' 3""",245 lbs.,--,Orthodox,"Dec 31, 1970",http://ufcstats.com/fighter-details/02e52b3a595f0786
 Joe Jordan,"5' 6""",155 lbs.,--,Orthodox,"Jul 27, 1978",http://ufcstats.com/fighter-details/712c4db78b9373d1
@@ -1623,29 +1844,36 @@ Dwight Joseph,"5' 6""",135 lbs.,--,Switch,"Aug 16, 1989",http://ufcstats.com/fig
 Jeff Joslin,"6' 0""",170 lbs.,--,Orthodox,"Apr 30, 1975",http://ufcstats.com/fighter-details/388abbf8832b5adf
 Krzysztof Jotko,"6' 1""",185 lbs.,"77""",Southpaw,"Aug 19, 1989",http://ufcstats.com/fighter-details/4e06913c91da5200
 Alan Jouban,"6' 0""",170 lbs.,"73""",Southpaw,"Nov 25, 1981",http://ufcstats.com/fighter-details/cf65d56b0755ed3b
-Charles Jourdain,"5' 9""",145 lbs.,"69""",Switch,"Nov 27, 1995",http://ufcstats.com/fighter-details/f1d64ae34e088832
+Charles Jourdain,"5' 9""",135 lbs.,"69""",Switch,"Nov 27, 1995",http://ufcstats.com/fighter-details/f1d64ae34e088832
+Kevin Jousset,"6' 2""",170 lbs.,"75""",Orthodox,"May 02, 1993",http://ufcstats.com/fighter-details/dda15dbfafb792df
 Mike Joy,"5' 6""",155 lbs.,--,Southpaw,"Jul 18, 1985",http://ufcstats.com/fighter-details/35080a7f406f9ab3
 Dustin Joynson,"6' 6""",244 lbs.,"78""",Orthodox,"Oct 14, 1985",http://ufcstats.com/fighter-details/791367e8c35cfb6a
 Tony Juarez,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/97f3692d5444a80a
 Jesse Juarez,"6' 1""",170 lbs.,--,Orthodox,"May 08, 1981",http://ufcstats.com/fighter-details/cd039ff136d89ded
+Ernie Juarez,"5' 8""",145 lbs.,"70""",,"Jan 12, 1998",http://ufcstats.com/fighter-details/410898e8dd6ca9b6
+Anshul Jubli,"6' 0""",155 lbs.,"69""",Switch,"Jan 13, 1995",http://ufcstats.com/fighter-details/a72a2a769fa5a2be
+Carli Judice,"5' 7""",125 lbs.,"68""",Southpaw,"Mar 02, 1999",http://ufcstats.com/fighter-details/f1ab6f37492c630a
 Steve Judson,"5' 11""",230 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/6ece1d2ab1bed31d
 Luke Jumeau,"5' 11""",170 lbs.,"72""",Orthodox,"Feb 12, 1988",http://ufcstats.com/fighter-details/4c288a2b250bb576
 Bu-Kyung Jung,"5' 7""",154 lbs.,--,Orthodox,"May 26, 1978",http://ufcstats.com/fighter-details/b35d1650c78c2948
 Chan Sung Jung,"5' 7""",145 lbs.,"72""",Orthodox,"Mar 17, 1987",http://ufcstats.com/fighter-details/c451d67c09c55418
 Young Sam Jung,"5' 8""",139 lbs.,--,Orthodox,"Oct 27, 1985",http://ufcstats.com/fighter-details/13104eaed3ae96c3
-Da-Un Jung,"6' 4""",205 lbs.,"78""",Orthodox,"Dec 07, 1993",http://ufcstats.com/fighter-details/74f9448b97bf8bec
+Da Woon Jung,"6' 4""",205 lbs.,"78""",Orthodox,"Dec 07, 1993",http://ufcstats.com/fighter-details/74f9448b97bf8bec
 Scott Junk,"6' 1""",265 lbs.,--,Orthodox,"Dec 17, 1978",http://ufcstats.com/fighter-details/ac70a4f1db1b8c40
 Myles Jury,"5' 10""",145 lbs.,"73""",Orthodox,"Oct 31, 1988",http://ufcstats.com/fighter-details/08e908ed6d18d6a0
 Cristiane Justino,"5' 8""",145 lbs.,"68""",Orthodox,"Jul 09, 1985",http://ufcstats.com/fighter-details/634bb0de2eb043b4
 Patrick Kaase,"5' 9""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/b180f05acb24d430
 Emily Kagan,"5' 3""",115 lbs.,--,,"Jul 14, 1981",http://ufcstats.com/fighter-details/c1ea9d56cd953586
 Oron Kahlon,"5' 8""",135 lbs.,"70""",Orthodox,"Nov 04, 1984",http://ufcstats.com/fighter-details/00a35c92b03992b0
+Kaiwen,"5' 9""",145 lbs.,"72""",Switch,"Oct 16, 1995",http://ufcstats.com/fighter-details/0565706b1e7f7e7c
 Sirwan Kakai,"5' 5""",135 lbs.,--,Orthodox,"Oct 03, 1989",http://ufcstats.com/fighter-details/2525a853486ee670
 Saidyokub Kakhramonov,"5' 8""",135 lbs.,"69""",Orthodox,"Nov 14, 1995",http://ufcstats.com/fighter-details/50a28b9f8314e008
 Geza Kalman,"6' 1""",200 lbs.,--,,--,http://ufcstats.com/fighter-details/304fcd812f12c589
 Bryson Kamaka,"5' 11""",170 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/9336e86cfd4ceaa1
 Kai Kamaka,"5' 7""",145 lbs.,"69""",Orthodox,"Jan 05, 1995",http://ufcstats.com/fighter-details/eee0ef3e2b14816b
+Shuya Kamikubo,"5' 5""",135 lbs.,"68""",Switch,"Apr 12, 1993",http://ufcstats.com/fighter-details/a46fa1c7972548d0
 Martin Kampmann,"6' 0""",170 lbs.,"72""",Orthodox,"Apr 17, 1982",http://ufcstats.com/fighter-details/8b69839f3555a67b
+Koya Kanda,"5' 9""",145 lbs.,"75""",Southpaw,"Dec 20, 1995",http://ufcstats.com/fighter-details/b42d3a1469dab722
 Bharat Kandare,"5' 7""",135 lbs.,"72""",Orthodox,"Jun 20, 1987",http://ufcstats.com/fighter-details/efd2b3e9bb7965a4
 Hiromitsu Kanehara,"5' 10""",200 lbs.,--,Orthodox,"Oct 05, 1970",http://ufcstats.com/fighter-details/eda579d906cf0ca2
 Masanori Kanehara,"5' 7""",135 lbs.,"67""",Orthodox,"Nov 19, 1982",http://ufcstats.com/fighter-details/f3a078277b3b8ff4
@@ -1657,7 +1885,9 @@ David Kaplan,"5' 7""",155 lbs.,--,Orthodox,"Nov 16, 1979",http://ufcstats.com/fi
 Kai Kara-France,"5' 4""",125 lbs.,"69""",Orthodox,"Mar 26, 1993",http://ufcstats.com/fighter-details/853eb0dd5c0e2149
 Georgi Karakhanyan,"5' 8""",145 lbs.,--,,"May 29, 1985",http://ufcstats.com/fighter-details/43292ecf0e72c143
 Alex Karalexis,"5' 8""",155 lbs.,"66""",Orthodox,"Sep 20, 1977",http://ufcstats.com/fighter-details/e361e5c858af6ff1
+Ernesta Kareckaite,"5' 9""",125 lbs.,"71""",Orthodox,"Jul 05, 1998",http://ufcstats.com/fighter-details/e4faa79383c9f214
 Impa Kasanganay,"5' 11""",170 lbs.,"75""",Orthodox,"Jan 17, 1994",http://ufcstats.com/fighter-details/257b0c8d6f199895
+Jinnosuke Kashimura,"5' 7""",155 lbs.,"71""",Southpaw,"Aug 12, 2001",http://ufcstats.com/fighter-details/4a9120fa47bafef0
 Nadia Kassem,"5' 5""",125 lbs.,"66""",Southpaw,"Nov 15, 1995",http://ufcstats.com/fighter-details/6e7506127408aa9e
 Yusuke Kasuya,"5' 7""",155 lbs.,--,Southpaw,"Nov 16, 1989",http://ufcstats.com/fighter-details/3058888c33149a53
 Tetsuji Kato,--,155 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/542db012217ecb83
@@ -1665,11 +1895,14 @@ Hisaki Kato,"6' 0""",185 lbs.,--,,"Sep 17, 1982",http://ufcstats.com/fighter-det
 Brad Katona,"5' 6""",135 lbs.,"64""",Orthodox,"Dec 19, 1991",http://ufcstats.com/fighter-details/7b433309b0fd12aa
 Calvin Kattar,"5' 11""",145 lbs.,"72""",Orthodox,"Mar 26, 1988",http://ufcstats.com/fighter-details/751de04455cfaac0
 Sarah Kaufman,"5' 5""",135 lbs.,"66""",Orthodox,"Sep 20, 1985",http://ufcstats.com/fighter-details/36df8e119aec6175
+Lone'er Kavanagh,"5' 4""",125 lbs.,"67""",Orthodox,"Jun 09, 1999",http://ufcstats.com/fighter-details/bb2c3c3a466224af
 Yusuke Kawaguchi,"6' 0""",255 lbs.,--,,"Aug 14, 1980",http://ufcstats.com/fighter-details/fa2320781bfe4f49
 Canaan Kawaihae,"6' 0""",145 lbs.,"71""",Southpaw,"Aug 26, 1997",http://ufcstats.com/fighter-details/58d42b9e920b25fc
 Tatsuya Kawajiri,"5' 7""",145 lbs.,"69""",Orthodox,"May 08, 1978",http://ufcstats.com/fighter-details/80d918336163b80c
 Ryo Kawamura,"5' 11""",205 lbs.,--,Orthodox,"Jun 29, 1981",http://ufcstats.com/fighter-details/9e91d7fd2720e241
+Masuto Kawana,"5' 6""",145 lbs.,"69""",Orthodox,"Jan 30, 1995",http://ufcstats.com/fighter-details/49f4171f14f54220
 Doug Kay,--,--,--,,--,http://ufcstats.com/fighter-details/547c5611bd366988
+Toshiomi Kazama,"5' 7""",135 lbs.,"69""",Orthodox,"May 15, 1997",http://ufcstats.com/fighter-details/148bb103cfbf123e
 Julie Kedzie,"5' 5""",135 lbs.,--,Orthodox,"Mar 18, 1981",http://ufcstats.com/fighter-details/981ab7a0576f76a0
 Ryan Keenan,"5' 10""",170 lbs.,--,,"Jun 15, 1985",http://ufcstats.com/fighter-details/a72b20136239ba39
 CJ Keith,"6' 0""",155 lbs.,--,Orthodox,"Aug 09, 1986",http://ufcstats.com/fighter-details/c0eecd851dbf3146
@@ -1685,6 +1918,7 @@ Steve Kennedy,"5' 11""",170 lbs.,--,Orthodox,"Mar 07, 1983",http://ufcstats.com/
 Jeremy Kennedy,"5' 11""",145 lbs.,"71""",Orthodox,"Sep 16, 1992",http://ufcstats.com/fighter-details/68f6e96c5fa6e044
 Waylon Kennell,"6' 0""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/9b8a73b59be8d786
 Casey Kenney,"5' 7""",135 lbs.,"68""",Southpaw,"Mar 20, 1991",http://ufcstats.com/fighter-details/e7bba7ce4d6c7b07
+Maimaitituoheti Keremuaili,"5' 6""",135 lbs.,"66""",Orthodox,"Mar 18, 1991",http://ufcstats.com/fighter-details/772022b989534f0d
 Aurelijus Kerpe,--,--,--,Orthodox,--,http://ufcstats.com/fighter-details/c1e4ae143cce7398
 Mark Kerr,"6' 3""",266 lbs.,--,Switch,"Dec 21, 1968",http://ufcstats.com/fighter-details/a7b48e18ca27795d
 Will Kerr,"5' 10""",155 lbs.,"69""",Orthodox,"Oct 21, 1982",http://ufcstats.com/fighter-details/ef61d9f5176b3200
@@ -1695,6 +1929,7 @@ Sergey Khandozhko,"6' 1""",170 lbs.,"74""",Orthodox,"May 19, 1992",http://ufcsta
 Sergei Kharitonov,"6' 0""",245 lbs.,--,Orthodox,"Aug 18, 1980",http://ufcstats.com/fighter-details/0693b2eab79198ea
 Alfred Khashakyan,"5' 8""",135 lbs.,"70""",Orthodox,"Jul 17, 1988",http://ufcstats.com/fighter-details/3929efe0c0a83d07
 Aliaskhab Khizriev,"5' 9""",185 lbs.,"74""",Southpaw,"Aug 24, 1990",http://ufcstats.com/fighter-details/7ab478c397cd68ef
+WonBin Ki,"5' 11""",155 lbs.,"73""",Orthodox,"Feb 11, 1991",http://ufcstats.com/fighter-details/aaeb55084b198a39
 Pannie Kianzad,"5' 7""",135 lbs.,"66""",Orthodox,"Dec 08, 1991",http://ufcstats.com/fighter-details/91dac5e69e28d5b5
 Akira Kikuchi,"5' 8""",155 lbs.,--,Orthodox,"Jul 23, 1978",http://ufcstats.com/fighter-details/9c37681096c6f3a9
 Katsunori Kikuno,"5' 8""",145 lbs.,"66""",Orthodox,"Oct 31, 1981",http://ufcstats.com/fighter-details/44470bfd9483c7ad
@@ -1708,25 +1943,39 @@ Jong Won Kim,"5' 7""",139 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-detail
 Min Soo Kim,"6' 1""",255 lbs.,--,Southpaw,"Jan 22, 1975",http://ufcstats.com/fighter-details/831b937811804dad
 Jong Man Kim,"5' 7""",139 lbs.,--,Orthodox,"Mar 03, 1978",http://ufcstats.com/fighter-details/dba230fe33011201
 Ji Yeon Kim,"5' 7""",125 lbs.,"72""",Orthodox,"Oct 18, 1989",http://ufcstats.com/fighter-details/a20f234df70f2182
+MinWoo Kim,"5' 8""",135 lbs.,"72""",Orthodox,"Jul 21, 1993",http://ufcstats.com/fighter-details/6343a95f1d9e6a33
+HanSeul Kim,"6' 1""",170 lbs.,"73""",Southpaw,"Jun 19, 1990",http://ufcstats.com/fighter-details/2bc47c7cc6c05bd7
+KyeungPyo Kim,"5' 9""",155 lbs.,"71""",Orthodox,"Jan 29, 1992",http://ufcstats.com/fighter-details/5a9f7b5ffebdd6e7
+Sangwook Kim,"6' 0""",155 lbs.,"72""",Orthodox,"Oct 17, 1993",http://ufcstats.com/fighter-details/a264d4e9a4d6bfe4
+SangWon Kim,"5' 9""",145 lbs.,"69""",Orthodox,"Sep 01, 1993",http://ufcstats.com/fighter-details/e9712cad24948ce1
+KyuSung Kim,"5' 11""",125 lbs.,"69""",Orthodox,"Nov 05, 1992",http://ufcstats.com/fighter-details/e7ecfab8fd86d3e1
+So Yul Kim,--,115 lbs.,--,,"May 25, 1997",http://ufcstats.com/fighter-details/864c07a7ff90caae
 Jeremy Kimball,"6' 0""",205 lbs.,"72""",Switch,"Jan 03, 1991",http://ufcstats.com/fighter-details/917a5cb9821df261
 Rob Kimmons,"5' 10""",185 lbs.,"73""",Orthodox,"Jan 30, 1981",http://ufcstats.com/fighter-details/054defd5420a551f
 Dustin Kimura,"5' 7""",135 lbs.,"71""",Orthodox,"May 21, 1989",http://ufcstats.com/fighter-details/fe91d254db77a7fc
 Taiei Kin,"5' 11""",185 lbs.,--,Orthodox,"Jul 08, 1970",http://ufcstats.com/fighter-details/c7ac79839e86ce33
 Mike King,"6' 3""",185 lbs.,--,,"Aug 04, 1983",http://ufcstats.com/fighter-details/564c2f5f9eb45d67
 Kyle Kingsbury,"6' 4""",205 lbs.,"79""",Orthodox,"Mar 22, 1982",http://ufcstats.com/fighter-details/b959e8c7fd8390d2
-Kamuela Kirk,"5' 10""",145 lbs.,"75""",Switch,"Apr 13, 1994",http://ufcstats.com/fighter-details/c7d7fda69ec410d3
+Yusaku Kinoshita,"6' 0""",170 lbs.,"71""",Southpaw,"Aug 21, 2000",http://ufcstats.com/fighter-details/21b5c82c1b89dab1
+Kamuela Kirk,"5' 10""",155 lbs.,"75""",Switch,"Apr 13, 1994",http://ufcstats.com/fighter-details/c7d7fda69ec410d3
 Yurij Kiseliov,"5' 8""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/51d2aaaca56e5b40
 Justine Kish,"5' 5""",125 lbs.,"64""",Orthodox,"Apr 13, 1988",http://ufcstats.com/fighter-details/928ae2e5b5f7a9ec
 Koji Kitao,"6' 7""",350 lbs.,--,Southpaw,"Oct 12, 1963",http://ufcstats.com/fighter-details/2a6f8136da1e52c0
 Satoru Kitaoka,"5' 6""",154 lbs.,--,,"Feb 04, 1980",http://ufcstats.com/fighter-details/e2ac5bb645f33088
-Ludovit Klein,"5' 7""",145 lbs.,"72""",Southpaw,"Feb 22, 1995",http://ufcstats.com/fighter-details/5b86d491d63890c5
+Top Noi Kiwram,"5' 5""",125 lbs.,"67""",Southpaw,"Aug 15, 1992",http://ufcstats.com/fighter-details/e065b4a42a6c2c79
+Ludovit Klein,"5' 7""",155 lbs.,"72""",Southpaw,"Feb 22, 1995",http://ufcstats.com/fighter-details/5b86d491d63890c5
+Nick Klein,"6' 1""",185 lbs.,"77""",Orthodox,"Sep 08, 1995",http://ufcstats.com/fighter-details/7eaa5e31c2dd86aa
 Seth Kleinbeck,"6' 2""",185 lbs.,--,,"Jul 25, 1973",http://ufcstats.com/fighter-details/8ad022dd81224f61
 Stefan Klever,--,185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/bc3876891e155bb5
+Fatima Kline,"5' 6""",115 lbs.,"67""",Orthodox,"Jul 12, 2000",http://ufcstats.com/fighter-details/745fa7b605f8e2da
+Felix Klinkhammer,"6' 0""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/8276f28f1ad087de
 Drakkar Klose,"5' 9""",155 lbs.,"70""",Orthodox,"Mar 09, 1988",http://ufcstats.com/fighter-details/7cbf7c78d3b34218
 Michael Knaap,"6' 2""",220 lbs.,--,Orthodox,"Feb 27, 1984",http://ufcstats.com/fighter-details/02f0e04acf102ea9
 Kevin Knabjian,"5' 10""",170 lbs.,--,Orthodox,"Jul 05, 1984",http://ufcstats.com/fighter-details/1fac46d466abd5b8
 Jason Knight,"5' 10""",145 lbs.,"71""",Orthodox,"Jul 14, 1992",http://ufcstats.com/fighter-details/bb1a2cdad6ff34db
 William Knight,"5' 10""",205 lbs.,"73""",Orthodox,"Apr 03, 1988",http://ufcstats.com/fighter-details/5da33b8fbfa5ee95
+Josefine Knutsson,"5' 3""",115 lbs.,"60""",Orthodox,"Jan 16, 1996",http://ufcstats.com/fighter-details/971dba22c622af12
+Seokhyeon Ko,"5' 10""",170 lbs.,"71""",Southpaw,"Sep 24, 1993",http://ufcstats.com/fighter-details/4a07b1988477502c
 Isao Kobayashi,"5' 8""",145 lbs.,--,,"Oct 28, 1988",http://ufcstats.com/fighter-details/a02652d063ef5baa
 Kelly Kobold,"5' 6""",135 lbs.,--,Orthodox,"Feb 25, 1983",http://ufcstats.com/fighter-details/c398235fcaf8d71d
 Erik Koch,"5' 10""",170 lbs.,"71""",Southpaw,"Oct 04, 1988",http://ufcstats.com/fighter-details/99bd87a300079ed9
@@ -1745,6 +1994,7 @@ Roman Kopylov,"6' 0""",185 lbs.,"75""",Southpaw,"May 04, 1991",http://ufcstats.c
 Bruno Korea,"5' 6""",135 lbs.,"65""",,"Jun 28, 1991",http://ufcstats.com/fighter-details/6c011be66326ad97
 Andrey Koreshkov,"6' 0""",170 lbs.,--,,"Aug 23, 1990",http://ufcstats.com/fighter-details/aee885b8ca29ab4f
 Josh Koscheck,"5' 10""",170 lbs.,"73""",Orthodox,"Nov 30, 1977",http://ufcstats.com/fighter-details/dd37fd509af89f15
+Steven Koslow,"5' 7""",125 lbs.,"69""",Switch,"Jan 22, 1997",http://ufcstats.com/fighter-details/84512339473dd300
 Naoyuki Kotani,"5' 8""",155 lbs.,"66""",Southpaw,"Dec 08, 1981",http://ufcstats.com/fighter-details/bc8f6b42767e28df
 Ilya Kotau,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/a68d57ae177a5815
 Iouri Kotchkine,"6' 2""",235 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/c6becb722706c7d8
@@ -1756,6 +2006,7 @@ Derrick Krantz,"5' 10""",170 lbs.,"72""",Orthodox,"Jan 13, 1988",http://ufcstats
 James Krause,"6' 2""",170 lbs.,"73""",Orthodox,"Jun 04, 1986",http://ufcstats.com/fighter-details/8f6a18831a120817
 Pascal Krauss,"6' 1""",170 lbs.,--,Orthodox,"Apr 19, 1987",http://ufcstats.com/fighter-details/a01e84abefd85ec0
 Rene Kronvold,"5' 8""",170 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/db05271715bb4874
+Kaynan Kruschewsky,"6' 0""",155 lbs.,"73""",Orthodox,"Apr 04, 1991",http://ufcstats.com/fighter-details/ca36633b80be4a78
 Jorgen Kruth,"6' 2""",205 lbs.,--,,"May 08, 1974",http://ufcstats.com/fighter-details/6071d786f6187810
 Nikita Krylov,"6' 3""",205 lbs.,"77""",Orthodox,"Mar 07, 1992",http://ufcstats.com/fighter-details/1091d4d957141094
 Mariusz Ksiazkiewicz,"6' 3""",185 lbs.,"75""",Southpaw,"Oct 04, 1989",http://ufcstats.com/fighter-details/ab16537dd1e5e81d
@@ -1764,11 +2015,11 @@ John Kuhner,--,170 lbs.,--,,"Oct 12, 1982",http://ufcstats.com/fighter-details/a
 Michael Kuiper,"6' 0""",185 lbs.,"73""",Orthodox,"Jun 07, 1989",http://ufcstats.com/fighter-details/b7f38813485745da
 Anton Kuivanen,"5' 8""",155 lbs.,"72""",Orthodox,"May 01, 1984",http://ufcstats.com/fighter-details/706f8e2b34e8e18b
 Maiju Kujala,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/4e77d070239699e2
+Sumit Kumar,"5' 5""",125 lbs.,"66""",Orthodox,"Sep 09, 2000",http://ufcstats.com/fighter-details/a0a625221e0dd339
 Aleksei Kunchenko,"5' 8""",170 lbs.,"70""",Orthodox,"May 02, 1984",http://ufcstats.com/fighter-details/e2ccd9a9ace60de7
 Rizvan Kuniev,"6' 4""",240 lbs.,"76""",Orthodox,"Oct 03, 1992",http://ufcstats.com/fighter-details/739fd4fbb5d862f4
 Keigo Kunihara,"6' 0""",235 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/782a2a17d3e38fdf
 Kiichi Kunimoto,"5' 10""",170 lbs.,"71""",Orthodox,"May 01, 1981",http://ufcstats.com/fighter-details/71df36d6d8cf0d74
-Yana Kunitskaya,"5' 6""",135 lbs.,"68""",Orthodox,"Nov 11, 1989",http://ufcstats.com/fighter-details/3143bf892608139a
 Leo Kuntz,"5' 10""",155 lbs.,--,Orthodox,"Oct 03, 1983",http://ufcstats.com/fighter-details/6905d45bd71b50a9
 Korey Kuppe,"6' 5""",170 lbs.,"77""",Switch,"Jan 23, 1989",http://ufcstats.com/fighter-details/780a2897055e3ee3
 Ramazan Kuramagomedov,"6' 1""",170 lbs.,"73""",Orthodox,"Aug 23, 1996",http://ufcstats.com/fighter-details/b6a73e6f11a8835c
@@ -1776,16 +2027,21 @@ Tsuyoshi Kurihara,"5' 10""",185 lbs.,--,Orthodox,"Jul 13, 1973",http://ufcstats.
 Eldari Kurtanidze,"5' 6""",235 lbs.,--,Orthodox,"Apr 16, 1972",http://ufcstats.com/fighter-details/4c78fc005a53831d
 Kyle Kurtz,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/b490def93478ae29
 Guram Kutateladze,"5' 11""",155 lbs.,"72""",Orthodox,"Jan 08, 1992",http://ufcstats.com/fighter-details/7772b283d288dbe2
+Vadym Kutsyi,"6' 0""",170 lbs.,"71""",Orthodox,"Jul 18, 1991",http://ufcstats.com/fighter-details/aeb2bcd4371f40d5
 Lina Kvokov,"5' 9""",135 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/843dd76c50cae0f6
 Kaleo Kwan,"5' 7""",155 lbs.,--,,"Aug 01, 1970",http://ufcstats.com/fighter-details/2545c7f47a65bca3
 Jarrod Kwitty,"5' 8""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/849d15ed7e3a0e97
 Mike Kyle,"6' 4""",205 lbs.,"77""",Orthodox,"Mar 31, 1980",http://ufcstats.com/fighter-details/56b8b24f65f9f057
+Lisa Kyriacou,"5' 5""",125 lbs.,"64""",Orthodox,"Nov 17, 1993",http://ufcstats.com/fighter-details/edbc609a3b0d2aba
 Achmed Labasanov,"6' 3""",215 lbs.,--,Orthodox,"Apr 24, 1978",http://ufcstats.com/fighter-details/b3fb8d2293e17a59
 Josh LaBerge,"5' 10""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/5108b169b5fe1f86
 Jeremiah Labiano,"5' 10""",135 lbs.,--,,--,http://ufcstats.com/fighter-details/4fe1d105af549845
+Daniel Lacerda,"5' 6""",125 lbs.,"70""",Switch,"Jun 05, 1996",http://ufcstats.com/fighter-details/31bb0772f21cabd8
+Luan Lacerda,"5' 7""",135 lbs.,"71""",Orthodox,"Jan 07, 1993",http://ufcstats.com/fighter-details/6fc506e1099afe20
 Kemran Lachinov,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/eb84192d1a97f69e
-Aspen Ladd,"5' 6""",145 lbs.,"66""",Orthodox,"Mar 01, 1995",http://ufcstats.com/fighter-details/d4691518d012b9e7
+Aspen Ladd,"5' 6""",135 lbs.,"66""",Orthodox,"Mar 01, 1995",http://ufcstats.com/fighter-details/d4691518d012b9e7
 Ryan LaFlare,"6' 1""",170 lbs.,"74""",Southpaw,"Oct 01, 1983",http://ufcstats.com/fighter-details/4c7781da8c6cae93
+Corinne Laframboise,"5' 4""",125 lbs.,"65""",Orthodox,"May 25, 1989",http://ufcstats.com/fighter-details/fbe9f4efc2153be2
 Ben Lagman,"6' 2""",185 lbs.,--,,"Sep 04, 1986",http://ufcstats.com/fighter-details/b40e65d71a8d4ce5
 Noad Lahat,"5' 9""",145 lbs.,"69""",Orthodox,"Jun 08, 1984",http://ufcstats.com/fighter-details/9f755fb04cc21499
 Tina Lahdemaki,"5' 2""",115 lbs.,--,Orthodox,"May 28, 1988",http://ufcstats.com/fighter-details/e5ca2bc2451a5956
@@ -1797,7 +2053,7 @@ Ricardo Lamas,"5' 8""",145 lbs.,"71""",Orthodox,"May 21, 1982",http://ufcstats.c
 Jason Lambert,"6' 3""",185 lbs.,"75""",Orthodox,"Jun 03, 1975",http://ufcstats.com/fighter-details/5be86bb2f78fef2f
 Jose Landi-Jons,"5' 11""",170 lbs.,--,Orthodox,"Sep 09, 1973",http://ufcstats.com/fighter-details/7e062824c175f975
 Nate Landwehr,"5' 9""",145 lbs.,"72""",Orthodox,"Jun 06, 1988",http://ufcstats.com/fighter-details/583ee11abddfc581
-Austen Lane,"6' 6""",245 lbs.,--,Orthodox,"Nov 09, 1987",http://ufcstats.com/fighter-details/be9bdec19b7e9ffe
+Austen Lane,"6' 6""",245 lbs.,"80""",Orthodox,"Nov 09, 1987",http://ufcstats.com/fighter-details/be9bdec19b7e9ffe
 Aaron Lanfranco,--,155 lbs.,--,,"Aug 26, 1986",http://ufcstats.com/fighter-details/d73e856f150744b2
 Jeremy Lang,"5' 11""",205 lbs.,--,Southpaw,"May 11, 1975",http://ufcstats.com/fighter-details/09422812370fbdfe
 Lionel Lanham,--,205 lbs.,--,,"Aug 31, 1980",http://ufcstats.com/fighter-details/b8980dd7e8fc5976
@@ -1812,11 +2068,13 @@ Jeremy Larsen,"5' 10""",145 lbs.,"70""",Orthodox,"May 18, 1984",http://ufcstats.
 Brock Larson,"5' 11""",170 lbs.,"71""",Southpaw,"Aug 23, 1977",http://ufcstats.com/fighter-details/5eedbf1e9601be35
 Ryan Larson,--,170 lbs.,--,,"Dec 30, 1980",http://ufcstats.com/fighter-details/7107e53ebd7435fb
 Bobby Lashley,"6' 3""",255 lbs.,"78""",Orthodox,"Jul 16, 1976",http://ufcstats.com/fighter-details/b0826525fa17231d
-Ilir Latifi,"5' 10""",230 lbs.,"73""",Orthodox,"Jul 28, 1983",http://ufcstats.com/fighter-details/e9a3aeb207578eea
+Ilir Latifi,"5' 10""",230 lbs.,"73""",Orthodox,"Jul 28, 1982",http://ufcstats.com/fighter-details/e9a3aeb207578eea
 Sione Latu,"6' 0""",215 lbs.,--,,--,http://ufcstats.com/fighter-details/5898357a45a73674
+Phillip Latu,"6' 3""",205 lbs.,"76""",Orthodox,"Feb 17, 1991",http://ufcstats.com/fighter-details/09224b76d27007ee
 Jenel Lausa,"5' 5""",125 lbs.,"68""",Orthodox,"Aug 01, 1988",http://ufcstats.com/fighter-details/ec664422b22d9787
 Joe Lauzon,"5' 10""",155 lbs.,"71""",Orthodox,"May 22, 1984",http://ufcstats.com/fighter-details/3bad7ef643840f67
 Dan Lauzon,"5' 10""",155 lbs.,--,Orthodox,"Mar 30, 1988",http://ufcstats.com/fighter-details/4c8d6fde2dde07c4
+Sandra Lavado,"5' 7""",115 lbs.,"66""",Orthodox,"May 03, 1994",http://ufcstats.com/fighter-details/aa6da8cb3a26da04
 Chatt Lavender,"5' 8""",170 lbs.,--,,"May 24, 1976",http://ufcstats.com/fighter-details/5449dcccd972ff83
 Muhammed Lawal,"6' 0""",205 lbs.,"78""",Southpaw,"Jan 11, 1981",http://ufcstats.com/fighter-details/a571770c4016736f
 Robbie Lawler,"5' 11""",170 lbs.,"74""",Southpaw,"Mar 20, 1982",http://ufcstats.com/fighter-details/f2925e6db404bf1d
@@ -1825,11 +2083,14 @@ Justin Lawrence,"5' 8""",145 lbs.,"67""",Orthodox,"May 15, 1990",http://ufcstats
 Lance Lawrence,"6' 1""",145 lbs.,"74""",Orthodox,"Jun 26, 1993",http://ufcstats.com/fighter-details/ce039df1994b18f0
 Ronnie Lawrence,"5' 8""",135 lbs.,"68""",Switch,"Jun 13, 1992",http://ufcstats.com/fighter-details/e7e01e266a9d4342
 Eric Lawson,"6' 0""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/38e5d9dcb0fddc42
+Jimmy Lawson,"6' 0""",265 lbs.,"77""",Orthodox,"Nov 13, 1991",http://ufcstats.com/fighter-details/e43eefb10d440cb0
 Valmir Lazaro,"6' 0""",155 lbs.,"73""",Orthodox,"Aug 15, 1985",http://ufcstats.com/fighter-details/777dea713da2441d
 Zviad Lazishvili,"5' 6""",135 lbs.,"69""",Orthodox,"Oct 25, 1991",http://ufcstats.com/fighter-details/41498c2d1a87b154
 Mounir Lazzez,"6' 1""",170 lbs.,"76""",Orthodox,"Nov 16, 1987",http://ufcstats.com/fighter-details/49ee5024966efc0d
 Cung Le,"5' 9""",185 lbs.,"70""",Southpaw,"May 25, 1972",http://ufcstats.com/fighter-details/d4f364dd076bb0e2
 Thanh Le,"5' 9""",145 lbs.,"74""",Orthodox,"Aug 28, 1985",http://ufcstats.com/fighter-details/882b3f5a0774d575
+Quang Le,"5' 6""",135 lbs.,"70""",Orthodox,"Oct 18, 1991",http://ufcstats.com/fighter-details/32feae6d9a1e5047
+Carlos Leal,"5' 11""",170 lbs.,"74""",Orthodox,"May 04, 1994",http://ufcstats.com/fighter-details/28d421729451c8ca
 Jordan Leavitt,"5' 9""",155 lbs.,"71""",Southpaw,"Jun 02, 1995",http://ufcstats.com/fighter-details/ac026518a9b4dc0f
 Jerome LeBanner,"6' 3""",265 lbs.,--,Southpaw,"Dec 26, 1972",http://ufcstats.com/fighter-details/2d0b10789feafddb
 Chris Leben,"5' 11""",185 lbs.,"73""",Southpaw,"Jul 21, 1980",http://ufcstats.com/fighter-details/d43a048a880efdff
@@ -1848,9 +2109,13 @@ Vaughan Lee,"5' 6""",125 lbs.,"66""",Orthodox,"Oct 15, 1982",http://ufcstats.com
 Kevin Lee,"5' 9""",170 lbs.,"77""",Orthodox,"Sep 04, 1992",http://ufcstats.com/fighter-details/ee9ebceabfd16fa7
 Rocky Lee,"5' 9""",145 lbs.,--,Orthodox,"Apr 08, 1987",http://ufcstats.com/fighter-details/0d1c163b206e8c5f
 Andrea Lee,"5' 6""",125 lbs.,"69""",Orthodox,"Feb 11, 1989",http://ufcstats.com/fighter-details/05fa626cb33d15b8
+JeongYeong Lee,"5' 10""",145 lbs.,"73""",Orthodox,"Nov 13, 1995",http://ufcstats.com/fighter-details/d008d785f6347dc2
+JungHyun Lee,"5' 5""",125 lbs.,"65""",Orthodox,"Sep 10, 2002",http://ufcstats.com/fighter-details/b6033505c245e28b
+ChangHo Lee,"5' 8""",135 lbs.,"69""",Orthodox,"May 09, 1994",http://ufcstats.com/fighter-details/117a06469813e4ef
 Ricky Legere Jr.,"5' 8""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/5817df778cc27274
 Sherron Leggett,"5' 8""",155 lbs.,--,Southpaw,"Oct 27, 1978",http://ufcstats.com/fighter-details/4f670b7972fa0a2e
 Cheyden Leialoha,"5' 8""",135 lbs.,"73""",Orthodox,"Mar 15, 1994",http://ufcstats.com/fighter-details/98cbbc06074c68a4
+Claudia Leite,"5' 3""",135 lbs.,"64""",Orthodox,"Nov 04, 1996",http://ufcstats.com/fighter-details/90550a08f0b02b6f
 Thales Leites,"6' 1""",185 lbs.,"78""",Orthodox,"Sep 06, 1981",http://ufcstats.com/fighter-details/cfb65863d5099327
 Stefan Leko,"6' 2""",215 lbs.,--,Orthodox,"Jun 03, 1974",http://ufcstats.com/fighter-details/d56bb6dff2ae77eb
 Gabe Lemley,"5' 8""",155 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/fd4578cac86d75ca
@@ -1870,7 +2135,7 @@ Lukasz Les,--,170 lbs.,--,,"Nov 05, 1981",http://ufcstats.com/fighter-details/5a
 Brock Lesnar,"6' 3""",265 lbs.,"81""",Orthodox,"Jul 12, 1977",http://ufcstats.com/fighter-details/513c6f1715e547a8
 Frank Lester,"5' 11""",170 lbs.,--,Orthodox,"Jun 10, 1984",http://ufcstats.com/fighter-details/edd8d5d8089a35f8
 Valerie Letourneau,"5' 7""",115 lbs.,"68""",Orthodox,"Apr 29, 1983",http://ufcstats.com/fighter-details/46a2f24feb258ae0
-Leah Letson,"5' 7""",145 lbs.,"71""",,"Aug 21, 1992",http://ufcstats.com/fighter-details/8cb78f3a6c2a08f7
+Leah Letson,"5' 7""",145 lbs.,"71""",Southpaw,"Aug 21, 1992",http://ufcstats.com/fighter-details/8cb78f3a6c2a08f7
 Justin Levens,"5' 11""",185 lbs.,--,Orthodox,"Apr 18, 1980",http://ufcstats.com/fighter-details/8c3f3c43c8ceb778
 Marcus LeVesseur,"5' 9""",155 lbs.,"70""",Southpaw,"Jul 17, 1982",http://ufcstats.com/fighter-details/182f2b78582de3d8
 David Levicki,"6' 5""",275 lbs.,--,,--,http://ufcstats.com/fighter-details/49590e0508b2c19f
@@ -1879,11 +2144,15 @@ Natan Levy,"5' 9""",155 lbs.,"71""",Southpaw,"Sep 30, 1991",http://ufcstats.com/
 John Lewis,"6' 0""",155 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/4a01dc8376736ef5
 Derrick Lewis,"6' 3""",260 lbs.,"79""",Orthodox,"Feb 07, 1985",http://ufcstats.com/fighter-details/d3df1add9d9a7efb
 Bevon Lewis,"6' 3""",185 lbs.,"79""",Orthodox,"May 05, 1991",http://ufcstats.com/fighter-details/899923ff6ab13917
-Brandon Lewis,"5' 4""",135 lbs.,"65""",Orthodox,"Aug 02, 1997",http://ufcstats.com/fighter-details/6623cb1c27025634
+Brandon Lewis,"5' 4""",135 lbs.,"70""",Orthodox,"Aug 02, 1997",http://ufcstats.com/fighter-details/6623cb1c27025634
+Malik Lewis,"6' 0""",155 lbs.,"75""",Orthodox,"Mar 04, 1996",http://ufcstats.com/fighter-details/f60dbe6e05489c4f
 Chi Lewis-Parry,"6' 9""",243 lbs.,--,,"Aug 10, 1983",http://ufcstats.com/fighter-details/a307a10414d0ad00
 Li Jingliang,"6' 0""",170 lbs.,"71""",Orthodox,"Mar 20, 1988",http://ufcstats.com/fighter-details/e64b96c07d7ce999
+Li Yunfeng,"5' 8""",135 lbs.,"68""",Orthodox,"Mar 08, 1999",http://ufcstats.com/fighter-details/4c7afd56ef1947ac
+Liang Na,"5' 5""",125 lbs.,"67""",Orthodox,"Jul 27, 1996",http://ufcstats.com/fighter-details/ec0dcceace7d25a3
 Jess Liaudin,"5' 9""",170 lbs.,"72""",Orthodox,--,http://ufcstats.com/fighter-details/a8aba6fd8a463043
 Chuck Liddell,"6' 2""",205 lbs.,"76""",Orthodox,"Dec 17, 1969",http://ufcstats.com/fighter-details/a390eb8a9b2df298
+Rodrigo Lidio,"5' 11""",155 lbs.,"73""",Orthodox,"Jul 07, 1989",http://ufcstats.com/fighter-details/11b5a809c3120e27
 Sam Liera,--,--,--,,--,http://ufcstats.com/fighter-details/421ccfc6ddb17958
 Zach Light,"5' 8""",170 lbs.,--,Orthodox,"Feb 06, 1974",http://ufcstats.com/fighter-details/5d7c18191b8aa432
 Scott Lighty,"6' 2""",205 lbs.,--,,"Oct 15, 1978",http://ufcstats.com/fighter-details/998c8890a8dde1eb
@@ -1895,21 +2164,26 @@ Juliana Lima,"5' 5""",115 lbs.,"65""",Orthodox,"Mar 15, 1982",http://ufcstats.co
 Dhiego Lima,"6' 2""",170 lbs.,"75""",Orthodox,"Jan 31, 1989",http://ufcstats.com/fighter-details/e9213f53ddeca978
 Douglas Lima,"6' 1""",170 lbs.,--,,"Jan 05, 1988",http://ufcstats.com/fighter-details/264111bf62662fbf
 Mabelly Lima,"5' 2""",135 lbs.,--,Orthodox,"Jan 25, 1994",http://ufcstats.com/fighter-details/6135fd9665fbb74e
+Andre Lima,"5' 7""",125 lbs.,"67""",Orthodox,"Feb 04, 1999",http://ufcstats.com/fighter-details/b1f21ce050035d58
+Felipe Lima,"5' 6""",145 lbs.,"68""",Orthodox,"May 07, 1998",http://ufcstats.com/fighter-details/9256f591b30c073e
 Miguel Linares,--,--,--,,--,http://ufcstats.com/fighter-details/18c49685296c60e6
+Emiliano Linares,"5' 8""",145 lbs.,"72""",Orthodox,"Apr 21, 1997",http://ufcstats.com/fighter-details/a4ef92274a45143d
 Matt Lindland,"6' 0""",185 lbs.,"74""",Southpaw,"May 17, 1970",http://ufcstats.com/fighter-details/0e041d43a47d2e4b
 Jake Lindsey,"5' 11""",155 lbs.,--,Switch,"Jun 21, 1986",http://ufcstats.com/fighter-details/33e00249ef08d3a4
 John Lineker,"5' 3""",135 lbs.,"67""",Orthodox,"Jun 12, 1990",http://ufcstats.com/fighter-details/c268b2cfebccf652
 Austin Lingo,"5' 10""",145 lbs.,"70""",Orthodox,"Jul 10, 1994",http://ufcstats.com/fighter-details/305d73ede05e31ad
 Lucio Linhares,"6' 2""",185 lbs.,--,Orthodox,"Dec 08, 1973",http://ufcstats.com/fighter-details/a780d16cf7eed44d
-Philipe Lins,"6' 2""",240 lbs.,"78""",Orthodox,"Aug 17, 1985",http://ufcstats.com/fighter-details/53c943c873cffe90
-Ariane Lipski,"5' 6""",125 lbs.,"67""",Orthodox,"Jan 26, 1994",http://ufcstats.com/fighter-details/6551c64fbcd1a467
+Philipe Lins,"6' 2""",205 lbs.,"78""",Orthodox,"Aug 17, 1985",http://ufcstats.com/fighter-details/53c943c873cffe90
+Tainara Lisboa,"5' 7""",135 lbs.,"67""",Orthodox,"Mar 02, 1991",http://ufcstats.com/fighter-details/2c5f5749569eef66
 Dean Lister,"6' 1""",185 lbs.,"75""",Orthodox,"Feb 13, 1976",http://ufcstats.com/fighter-details/68c6cd5287b473a7
 Wesley Little,"6' 4""",205 lbs.,--,,--,http://ufcstats.com/fighter-details/008c6e1a25751575
+James Llontop,"6' 0""",155 lbs.,"73""",Orthodox,"Aug 02, 1999",http://ufcstats.com/fighter-details/93b2b7caa457cbea
 Abner Lloveras,"5' 11""",155 lbs.,--,,"Sep 04, 1982",http://ufcstats.com/fighter-details/6448e57a9533b7e4
 Brian Lo-A-Njoe,"5' 7""",155 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/7abce81b72fbbd9b
 John Lober,"5' 11""",199 lbs.,--,Orthodox,"Feb 26, 1968",http://ufcstats.com/fighter-details/31652c9267606d54
 Artem Lobov,"5' 9""",145 lbs.,"65""",Southpaw,"Aug 11, 1986",http://ufcstats.com/fighter-details/02f2a9702ba3d167
 Dylan Lockard,"5' 9""",145 lbs.,"72""",Orthodox,"May 19, 1992",http://ufcstats.com/fighter-details/9caa254991a5a698
+Ryan Loder,"6' 2""",185 lbs.,"76""",Southpaw,"Jun 05, 1991",http://ufcstats.com/fighter-details/d5bab53a1a603aac
 Sean Loeffler,"6' 3""",185 lbs.,--,Orthodox,"May 23, 1982",http://ufcstats.com/fighter-details/d3d1ff3f3dfa0931
 Christian Lohsen,"6' 2""",155 lbs.,"77""",Southpaw,"Jan 24, 1995",http://ufcstats.com/fighter-details/4ab36d70d1b28b58
 David Loiseau,"6' 0""",185 lbs.,"76""",Orthodox,"Dec 17, 1979",http://ufcstats.com/fighter-details/22e47b53e4ceb27c
@@ -1922,6 +2196,8 @@ Ange Loosa,"5' 10""",170 lbs.,"74""",Orthodox,"Mar 18, 1993",http://ufcstats.com
 Lucas Lopes,"6' 2""",185 lbs.,--,,"Oct 05, 1979",http://ufcstats.com/fighter-details/1f70dd67ad507990
 Dileno Lopes,"5' 5""",135 lbs.,--,,"Sep 26, 1984",http://ufcstats.com/fighter-details/8270c00fae24c922
 Diego Lopes,"5' 11""",145 lbs.,"72""",Orthodox,"Dec 30, 1994",http://ufcstats.com/fighter-details/f166e93d04a8c274
+Bruno Lopes,"6' 2""",205 lbs.,"74""",Orthodox,"Apr 24, 1993",http://ufcstats.com/fighter-details/0abcf6bc47191219
+Arthur Lopes,"6' 2""",234 lbs.,"77""",Southpaw,"Feb 17, 1993",http://ufcstats.com/fighter-details/2aa481e98185e261
 Ivan Lopez,"5' 6""",135 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/0db9d2486d564a3c
 Steve Lopez,"5' 11""",155 lbs.,--,Orthodox,"Jul 30, 1984",http://ufcstats.com/fighter-details/6085ceb59087514b
 Federico Lopez,"5' 4""",139 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/9681e0ce67dc978b
@@ -1932,37 +2208,46 @@ Benito Lopez,"5' 10""",135 lbs.,"73""",Switch,"Apr 06, 1994",http://ufcstats.com
 Gustavo Lopez,"5' 5""",135 lbs.,"67""",Orthodox,"Jun 27, 1989",http://ufcstats.com/fighter-details/93b62c5f2ba18e51
 Brendan Loughnane,"5' 10""",145 lbs.,"70""",Switch,"Dec 05, 1989",http://ufcstats.com/fighter-details/b788862dd1c11eac
 Nate Loughran,"6' 2""",185 lbs.,--,Orthodox,"Jul 28, 1980",http://ufcstats.com/fighter-details/cbf94e4c4af4ff6d
+Caolan Loughran,"5' 6""",135 lbs.,"68""",Orthodox,"May 18, 1996",http://ufcstats.com/fighter-details/42ac4020cba261ad
 Rashard Lovelace,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/e601d71cf8e5be22
 Ian Loveland,"5' 8""",145 lbs.,--,Orthodox,"Sep 07, 1983",http://ufcstats.com/fighter-details/eea0274e153256a0
 Jakob Lovstad,"6' 3""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/ad044be25c94dcfd
 Waylon Lowe,"5' 7""",145 lbs.,--,Southpaw,"Oct 31, 1980",http://ufcstats.com/fighter-details/28f62d866c59c709
 Brandon Lowe,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/78ac94d54aa7f378
 Joe Lowry,"5' 11""",155 lbs.,"73""",Orthodox,"Dec 12, 1989",http://ufcstats.com/fighter-details/86248c84834238e7
+Lu Kai,"5' 9""",145 lbs.,"69""",Orthodox,"Mar 01, 1994",http://ufcstats.com/fighter-details/a2d23e684b3db732
+Lu Zhengyong,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/dc1bfd47c3b21ad3
 Robert Lucarelli,"6' 2""",245 lbs.,--,,--,http://ufcstats.com/fighter-details/96087e90d900f0ef
 Matt Lucas,"6' 1""",205 lbs.,--,,--,http://ufcstats.com/fighter-details/668222c99c5c311d
 Cleber Luciano,"5' 6""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/9bdebbf2735d14c2
+Stephanie Luciano,"5' 6""",115 lbs.,"65""",Orthodox,"Dec 16, 1999",http://ufcstats.com/fighter-details/1b35af4d1529adf6
+Iasmin Lucindo,"5' 3""",115 lbs.,"66""",Orthodox,"Jan 08, 2002",http://ufcstats.com/fighter-details/abcf2cc6efc42031
 Duane Ludwig,"5' 10""",170 lbs.,"70""",Orthodox,"Aug 04, 1978",http://ufcstats.com/fighter-details/84ac950d4c1722dd
 Mike Lullo,"5' 8""",145 lbs.,--,Orthodox,"Jul 24, 1979",http://ufcstats.com/fighter-details/e26882820f9e8df5
+Paula Luna,"5' 2""",125 lbs.,"62""",Orthodox,"Jul 05, 1999",http://ufcstats.com/fighter-details/5b1effb0db45273a
 Dalcha Lungiambula,"5' 8""",185 lbs.,"76""",Orthodox,"Jul 31, 1987",http://ufcstats.com/fighter-details/ce632027bf2a871b
 Alexandru Lungu,"6' 0""",385 lbs.,--,Orthodox,"Sep 03, 1974",http://ufcstats.com/fighter-details/4887e5bc4dbb73ff
 Vicente Luque,"5' 11""",170 lbs.,"75""",Orthodox,"Nov 27, 1991",http://ufcstats.com/fighter-details/6d4b63c767106d3a
 Thaddeus Luster,"6' 3""",210 lbs.,--,,--,http://ufcstats.com/fighter-details/505934897b8b4824
 Travis Lutter,"5' 11""",185 lbs.,"75""",Orthodox,"May 12, 1973",http://ufcstats.com/fighter-details/622f015c81a9b13a
+Joilton Lutterbach,"6' 1""",185 lbs.,"75""",Orthodox,"Nov 05, 1992",http://ufcstats.com/fighter-details/12630a4aa0894da8
 Tucker Lutz,"5' 8""",145 lbs.,"72""",Orthodox,"Jul 12, 1994",http://ufcstats.com/fighter-details/7832f2f62f04178f
 Lv Zhenhong,"5' 8""",145 lbs.,"67""",Switch,"Jun 25, 1993",http://ufcstats.com/fighter-details/5a4913108a3b9190
 Stevie Lynch,"5' 10""",170 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/710d93f1508f7104
 Adam Lynn,"5' 10""",155 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/edfe95e3c33a4bf8
 Chris Lytle,"5' 11""",170 lbs.,"68""",Orthodox,"Aug 18, 1974",http://ufcstats.com/fighter-details/91acd6910b802a9e
 Dong Hyun Ma,"5' 11""",155 lbs.,"70""",Orthodox,"Sep 09, 1988",http://ufcstats.com/fighter-details/98a6b2361045898f
+Pawan Maan,"5' 7""",155 lbs.,"70""",Orthodox,"Apr 06, 1986",http://ufcstats.com/fighter-details/450bacdacd706bcd
 William Macario,"5' 11""",170 lbs.,"75""",Orthodox,"Jul 01, 1991",http://ufcstats.com/fighter-details/ed74afc8b5b47a61
 Jason MacDonald,"6' 3""",185 lbs.,"80""",Orthodox,"Jun 03, 1975",http://ufcstats.com/fighter-details/2be6596a9db33bf5
 Rob MacDonald,"6' 3""",205 lbs.,"78""",Orthodox,"Sep 05, 1978",http://ufcstats.com/fighter-details/f3388d2cf7ab3f64
 Rory MacDonald,"6' 0""",170 lbs.,"76""",Orthodox,"Jul 22, 1989",http://ufcstats.com/fighter-details/cbd5d3cdd862e90e
 Ryan MacDonald,"5' 11""",135 lbs.,"71""",Switch,"Mar 18, 1993",http://ufcstats.com/fighter-details/35e1f9984ed64206
-Veronica Macedo,"5' 4""",125 lbs.,"64""",Southpaw,"Oct 30, 1995",http://ufcstats.com/fighter-details/4798e823ada58fe9
 Clayton MacFarlane,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/39831e62d12e7ad1
 Ilima Macfarlane,"5' 4""",125 lbs.,--,,--,http://ufcstats.com/fighter-details/8cf90e41646491fd
 Valesca Machado,"5' 4""",115 lbs.,"63""",Orthodox,"May 06, 1996",http://ufcstats.com/fighter-details/a1a91dbf41a029c4
+Caio Machado,"6' 4""",250 lbs.,"78""",Southpaw,"Jul 20, 1994",http://ufcstats.com/fighter-details/89839250eb25c9c1
+Ian Machado Garry,"6' 3""",170 lbs.,"74""",Orthodox,"Nov 17, 1997",http://ufcstats.com/fighter-details/442c9011034ae1fd
 Lyoto Machida,"6' 1""",185 lbs.,"74""",Southpaw,"May 30, 1978",http://ufcstats.com/fighter-details/f7a7f7118d4b01b6
 War Machine,"5' 11""",170 lbs.,--,Orthodox,"Nov 30, 1981",http://ufcstats.com/fighter-details/cd7bafbeee1f29a0
 Anthony Macias,"5' 9""",185 lbs.,--,Switch,--,http://ufcstats.com/fighter-details/dedc3bb440d09554
@@ -1970,6 +2255,7 @@ Pauline Macias,"5' 4""",115 lbs.,"64""",Southpaw,"Jun 27, 1988",http://ufcstats.
 Reza Madadi,"5' 11""",155 lbs.,"73""",Orthodox,"Jun 20, 1978",http://ufcstats.com/fighter-details/e25bcbcdaf6537a1
 Don Madge,"6' 0""",155 lbs.,"72""",Southpaw,"Nov 12, 1990",http://ufcstats.com/fighter-details/68c7ad953455c73f
 Ryan Madigan,"6' 0""",170 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/a8d521d913df4e31
+Victor Madrigal,"5' 7""",135 lbs.,"71""",Orthodox,"Aug 16, 1990",http://ufcstats.com/fighter-details/cc63a5f0089d8ba9
 Jon Madsen,"6' 0""",240 lbs.,"72""",Orthodox,"Feb 12, 1980",http://ufcstats.com/fighter-details/7691a80e6ca3e55b
 Mark Madsen,"5' 8""",155 lbs.,"72""",Orthodox,"Sep 23, 1984",http://ufcstats.com/fighter-details/da0995f19b749cfa
 Yoshiro Maeda,"5' 7""",139 lbs.,"68""",Southpaw,"Oct 31, 1981",http://ufcstats.com/fighter-details/a4bf17bd3ba3423b
@@ -1982,24 +2268,29 @@ Eric Magana,--,--,--,,--,http://ufcstats.com/fighter-details/8db1b36dde268ef6
 Brandon Magana,--,170 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/2015c944226ad2df
 Angela Magana,"5' 1""",115 lbs.,"65""",Orthodox,"Aug 02, 1983",http://ufcstats.com/fighter-details/bd878a638e0e3be3
 Neil Magny,"6' 3""",170 lbs.,"80""",Orthodox,"Aug 03, 1987",http://ufcstats.com/fighter-details/84b3e7d38f2d2ec5
+Raimond Magomedaliev,"6' 1""",170 lbs.,"75""",Orthodox,"Jun 10, 1990",http://ufcstats.com/fighter-details/d16373b3568678d4
 Ibragim Magomedov,"6' 0""",250 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/e7e970d508529bf3
 Rashid Magomedov,"5' 9""",155 lbs.,"70""",Orthodox,"Nov 29, 1984",http://ufcstats.com/fighter-details/7ea1f74cef32f906
 Ruslan Magomedov,"6' 3""",242 lbs.,"78""",Orthodox,"Nov 26, 1986",http://ufcstats.com/fighter-details/369e1ce458ef50a6
-Abus Magomedov,"6' 2""",185 lbs.,--,,"Sep 02, 1990",http://ufcstats.com/fighter-details/36b8f265bcd1b7a4
+Abus Magomedov,"6' 2""",185 lbs.,"78""",Orthodox,"Sep 02, 1990",http://ufcstats.com/fighter-details/36b8f265bcd1b7a4
+Shara Magomedov,"6' 2""",185 lbs.,"73""",Orthodox,"May 16, 1994",http://ufcstats.com/fighter-details/06734ca9d88dec3a
 Zabit Magomedsharipov,"6' 1""",145 lbs.,"73""",Orthodox,"Mar 01, 1991",http://ufcstats.com/fighter-details/87aa9fb63d6b51a1
 John Maguire,"5' 9""",155 lbs.,"69""",Southpaw,"May 19, 1983",http://ufcstats.com/fighter-details/1a7745388839e52b
 Lolohea Mahe,--,--,--,,--,http://ufcstats.com/fighter-details/fb0b6593cec84356
 Michelle Maher,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/118463dd8db16e7f
-Maheshate,"6' 0""",155 lbs.,"71""",Orthodox,"Jan 12, 1999",http://ufcstats.com/fighter-details/8c1ca54b5089d199
+Maheshate,"6' 0""",155 lbs.,"71""",Orthodox,"Dec 01, 1999",http://ufcstats.com/fighter-details/8c1ca54b5089d199
 Bill Mahood,"6' 3""",200 lbs.,--,Orthodox,"Feb 01, 1967",http://ufcstats.com/fighter-details/ae58685caf8e4a0d
 Klayton Mai,"5' 9""",125 lbs.,--,,"Nov 30, 1986",http://ufcstats.com/fighter-details/7a9c1bb08a743d7f
 Demian Maia,"6' 1""",170 lbs.,"72""",Southpaw,"Nov 06, 1977",http://ufcstats.com/fighter-details/427b5953ac8e3a27
 Jennifer Maia,"5' 4""",125 lbs.,"64""",Orthodox,"Oct 06, 1988",http://ufcstats.com/fighter-details/8e1f36476ef02a6a
+Nayara Maia,"5' 5""",125 lbs.,"66""",Orthodox,"Jul 25, 1990",http://ufcstats.com/fighter-details/03b1b79b34eaf217
+Roshan Mainam,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/b301292b1bc92bdb
 Levan Makashvili,"5' 8""",145 lbs.,"68""",Orthodox,"Jan 07, 1989",http://ufcstats.com/fighter-details/938ad489fb7a1f31
 John Makdessi,"5' 8""",155 lbs.,"68""",Orthodox,"May 03, 1985",http://ufcstats.com/fighter-details/c21a036b4e012f1c
 Islam Makhachev,"5' 10""",155 lbs.,"70""",Southpaw,"Oct 27, 1991",http://ufcstats.com/fighter-details/275aca31f61ba28c
 Aliev Makhmud,"5' 6""",195 lbs.,--,Southpaw,"Feb 13, 1970",http://ufcstats.com/fighter-details/3d481aa374c954a1
 Zach Makovsky,"5' 4""",125 lbs.,"64""",Southpaw,"Apr 19, 1983",http://ufcstats.com/fighter-details/57ab4d7c0bc09a30
+Azat Maksum,"5' 7""",125 lbs.,"70""",Southpaw,"Feb 02, 1995",http://ufcstats.com/fighter-details/7f1bf0c255ec8756
 Jeremy Malaterre,"5' 11""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/110404b505fb562c
 Fabio Maldonado,"6' 1""",205 lbs.,"75""",Orthodox,"Mar 17, 1980",http://ufcstats.com/fighter-details/1fb80f46d3c105d9
 Marvin Maldonado,"5' 6""",135 lbs.,--,,--,http://ufcstats.com/fighter-details/e5ce754b01f922be
@@ -2008,24 +2299,30 @@ Nazareno Malegarie,"5' 8""",155 lbs.,--,,"May 16, 1986",http://ufcstats.com/figh
 Carl Malenko,"5' 11""",200 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/a314687f372b2cec
 Jacob Malkoun,"5' 9""",185 lbs.,"73""",Orthodox,"Aug 26, 1995",http://ufcstats.com/fighter-details/d4270315cbcf2569
 Mike Malott,"6' 1""",170 lbs.,"73""",Orthodox,"Nov 07, 1991",http://ufcstats.com/fighter-details/dd6103dd7127db1d
+Dan Manasoiu,--,--,--,,--,http://ufcstats.com/fighter-details/eefc73b53d4a05d7
 Troy Mandaloniz,"5' 9""",170 lbs.,--,Orthodox,"Feb 01, 1980",http://ufcstats.com/fighter-details/725a834930c2b5bf
-Nate Maness,"5' 10""",135 lbs.,"72""",Orthodox,"Jun 27, 1991",http://ufcstats.com/fighter-details/6e9f40c706f91f32
+Nate Maness,"5' 10""",125 lbs.,"72""",Orthodox,"Jun 27, 1991",http://ufcstats.com/fighter-details/6e9f40c706f91f32
 Michael Mangan,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/9297ce6eee046f7a
 Gary Mangat,"5' 7""",135 lbs.,--,,--,http://ufcstats.com/fighter-details/1c0ffc63d8ec8f45
 Melvin Manhoef,"5' 9""",185 lbs.,--,Orthodox,"May 11, 1976",http://ufcstats.com/fighter-details/e5767ed355a937c2
 Melchor Manibusan,"5' 5""",154 lbs.,--,Southpaw,"Dec 27, 1976",http://ufcstats.com/fighter-details/b6c6d1731ff00eeb
 Jon Manley,"6' 1""",170 lbs.,--,Orthodox,"Jul 07, 1986",http://ufcstats.com/fighter-details/a0602dd050bebefc
 Steve Mann,"6' 1""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/0eef1bf99afd4ff2
+Marnic Mann,"5' 0""",115 lbs.,"64""",Southpaw,"Mar 05, 1993",http://ufcstats.com/fighter-details/b6203e0492a9336c
+Dylan Mantello,"6' 1""",155 lbs.,"73""",Orthodox,"Nov 19, 1992",http://ufcstats.com/fighter-details/e192ebb85b68fa9e
 Chris Manuel,"5' 9""",135 lbs.,--,Orthodox,"Jul 21, 1987",http://ufcstats.com/fighter-details/a23e63184c65f5b8
 Jimi Manuwa,"6' 1""",205 lbs.,"79""",Orthodox,"Feb 18, 1980",http://ufcstats.com/fighter-details/1e1dbd1cc5a7469e
 Cristiano Marcello,"5' 9""",155 lbs.,"72""",Orthodox,"Dec 03, 1977",http://ufcstats.com/fighter-details/ff4c3ab594c7fac3
+Daniel Marcos,"5' 7""",135 lbs.,"69""",Orthodox,"Mar 07, 1993",http://ufcstats.com/fighter-details/850266b3dc4e506e
 Jose Maria,"5' 5""",125 lbs.,--,Orthodox,"Jan 04, 1982",http://ufcstats.com/fighter-details/b35ba64b6a2bbcb3
 Marcos Mariano,"6' 1""",155 lbs.,"76""",Switch,"Oct 12, 1986",http://ufcstats.com/fighter-details/72e5e5a6edfa8223
 Enrique Marin,"5' 10""",170 lbs.,--,,"Sep 02, 1986",http://ufcstats.com/fighter-details/23a6e307077c6ccc
+Chepe Mariscal,"5' 7""",145 lbs.,"69""",Orthodox,"Oct 27, 1992",http://ufcstats.com/fighter-details/e0c6edcb5b5d0b90
 Ronny Markes,"6' 1""",185 lbs.,"75""",Orthodox,"Apr 21, 1988",http://ufcstats.com/fighter-details/bd21a1e3d41c97ee
 Rory Markham,"6' 0""",170 lbs.,"71""",Orthodox,"Mar 25, 1982",http://ufcstats.com/fighter-details/23a16ebe733e3041
 Randa Markos,"5' 4""",115 lbs.,"63""",Orthodox,"Aug 10, 1985",http://ufcstats.com/fighter-details/4a57ebb14315b251
 Christina Marks,"5' 7""",125 lbs.,"69""",Orthodox,"Nov 08, 1985",http://ufcstats.com/fighter-details/c7be22a47a58365a
+Brendon Marotte,"5' 9""",145 lbs.,"70""",Orthodox,"Jan 12, 1996",http://ufcstats.com/fighter-details/d7fe8c6b7d2872e5
 Nate Marquardt,"6' 0""",185 lbs.,"74""",Orthodox,"Apr 20, 1979",http://ufcstats.com/fighter-details/a8e6a69796280f17
 Danilo Marques,"6' 6""",205 lbs.,"77""",Orthodox,"Dec 26, 1985",http://ufcstats.com/fighter-details/687c15b2eddfaa63
 Julian Marquez,"6' 2""",185 lbs.,"72""",Orthodox,"May 08, 1990",http://ufcstats.com/fighter-details/d0e1b42d41dab603
@@ -2036,6 +2333,7 @@ CJ Marsh,--,--,--,,--,http://ufcstats.com/fighter-details/4c91eb190d5e0dd9
 Eliot Marshall,"6' 2""",205 lbs.,"77""",Orthodox,"Jul 07, 1980",http://ufcstats.com/fighter-details/a08d909a5be6f410
 Doug Marshall,"5' 10""",205 lbs.,--,Orthodox,"Sep 09, 1975",http://ufcstats.com/fighter-details/0c1773639c795466
 David Marshall,"6' 2""",170 lbs.,--,,"Aug 24, 1984",http://ufcstats.com/fighter-details/0a2813f89a758ff7
+Francis Marshall,"5' 9""",145 lbs.,"72""",Orthodox,"Mar 03, 1999",http://ufcstats.com/fighter-details/5d495dec23d7c68e
 Jack Marshman,"6' 0""",185 lbs.,"73""",Orthodox,"Dec 19, 1989",http://ufcstats.com/fighter-details/045f25b3a4c08e81
 Terry Martin,"5' 8""",185 lbs.,"71""",Orthodox,"Oct 10, 1980",http://ufcstats.com/fighter-details/6a92caba39b64752
 Eric Martin,--,--,--,,--,http://ufcstats.com/fighter-details/abbc4fc02e0d84b3
@@ -2055,12 +2353,17 @@ Andrew Martinez,"5' 9""",215 lbs.,--,,--,http://ufcstats.com/fighter-details/f8c
 Mana Martinez,"5' 10""",135 lbs.,"70""",Orthodox,"Mar 25, 1996",http://ufcstats.com/fighter-details/c0386644627a7ee5
 Victor Martinez,"5' 8""",155 lbs.,"70""",Orthodox,"Jul 17, 1991",http://ufcstats.com/fighter-details/3e708ce33b6b18e6
 Roque Martinez,"5' 10""",250 lbs.,"72""",Orthodox,"Mar 04, 1986",http://ufcstats.com/fighter-details/2c5a0b8317f8f27a
+Melissa Martinez,"5' 2""",115 lbs.,"66""",Southpaw,"Aug 18, 1997",http://ufcstats.com/fighter-details/3f4c3bc822bea45d
+Julieta Martinez,"5' 1""",115 lbs.,"62""",Orthodox,"Sep 14, 2004",http://ufcstats.com/fighter-details/f77afa72da84c9a8
+David Martinez,"5' 6""",135 lbs.,"66""",Orthodox,"Aug 03, 1998",http://ufcstats.com/fighter-details/9a97acbfd5a08bfa
 Wagner da Conceicao Martins,"6' 7""",390 lbs.,--,Orthodox,"May 19, 1978",http://ufcstats.com/fighter-details/563d051c9e769b24
 Adriano Martins,"5' 10""",155 lbs.,"72""",Southpaw,"Dec 16, 1982",http://ufcstats.com/fighter-details/7dcf06c1967801c1
 Lucas Martins,"6' 0""",145 lbs.,"72""",Southpaw,"Nov 11, 1988",http://ufcstats.com/fighter-details/7413b80dbb0f8f9f
 Max Martyniouk,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/69d3fa376ff2595e
 Bristol Marunde,"6' 1""",170 lbs.,"75""",Orthodox,"Apr 20, 1982",http://ufcstats.com/fighter-details/a17322f99ddfd8e9
 Shoji Maruyama,"5' 7""",139 lbs.,--,Orthodox,"Apr 24, 1983",http://ufcstats.com/fighter-details/c046100aea0dba9a
+Kazuma Maruyama,"5' 11""",155 lbs.,"72""",Orthodox,"Jul 19, 1992",http://ufcstats.com/fighter-details/aa1a873d05acc7eb
+Islem Masraf,"6' 0""",205 lbs.,"74""",Southpaw,"Jun 07, 1996",http://ufcstats.com/fighter-details/6dedfe07640a9acc
 Mike Massenzio,"6' 2""",185 lbs.,"73""",Southpaw,"Nov 01, 1982",http://ufcstats.com/fighter-details/5b2d7906aa894274
 Jameel Massouh,"5' 10""",145 lbs.,"72""",Orthodox,"Sep 12, 1984",http://ufcstats.com/fighter-details/883922e5cd6d8473
 Tiffany Masters,"5' 3""",115 lbs.,"65""",Orthodox,"Jul 31, 1994",http://ufcstats.com/fighter-details/ca743f96dd2063d5
@@ -2068,10 +2371,14 @@ Jorge Masvidal,"5' 11""",170 lbs.,"74""",Orthodox,"Nov 12, 1984",http://ufcstats
 Al Matavao,"5' 8""",205 lbs.,"67""",Orthodox,"Feb 23, 1994",http://ufcstats.com/fighter-details/eec3fe66a8b11a26
 Tateki Matsuda,"5' 7""",125 lbs.,--,Orthodox,"Feb 27, 1986",http://ufcstats.com/fighter-details/3a524c6700addc24
 Daijiro Matsui,"5' 9""",200 lbs.,--,Orthodox,"Dec 05, 1972",http://ufcstats.com/fighter-details/cd42bbe8887bba90
+Toki Matsui,"5' 6""",125 lbs.,"65""",Orthodox,"Sep 08, 1999",http://ufcstats.com/fighter-details/56cc76c55cee8410
 Koichiro Matsumoto,"5' 7""",145 lbs.,--,,"Mar 07, 1986",http://ufcstats.com/fighter-details/2fb6f197d1fbc779
+Jean Matsumoto,"5' 6""",135 lbs.,"68""",Orthodox,"Sep 09, 1999",http://ufcstats.com/fighter-details/ffd3224638c01b57
+Koyomi Matsushima,"5' 7""",145 lbs.,"66""",Orthodox,"Oct 08, 1992",http://ufcstats.com/fighter-details/5ad226da6c74a48e
 Naoki Matsushita,"5' 6""",155 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/990060b2a68a7b82
 AJ Matthews,"5' 11""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/18e4f61f16f458c6
 Jake Matthews,"5' 11""",170 lbs.,"73""",Orthodox,"Aug 19, 1994",http://ufcstats.com/fighter-details/a845f0735bc67405
+Connor Matthews,"5' 8""",145 lbs.,"71""",Switch,"May 31, 1992",http://ufcstats.com/fighter-details/36e78278a77006d4
 Claudio Mattos,--,185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/6e2b1d631832921d
 John Matua,"6' 2""",400 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/c933d423ebdbbbdb
 Francesco Maturi,--,--,--,,--,http://ufcstats.com/fighter-details/d3b5ad3b15a64a18
@@ -2086,13 +2393,15 @@ Gray Maynard,"5' 9""",155 lbs.,"70""",Orthodox,"May 09, 1979",http://ufcstats.co
 Brooke Mayo,"5' 7""",125 lbs.,--,,--,http://ufcstats.com/fighter-details/1b41c21d947d6f2f
 Gina Mazany,"5' 6""",125 lbs.,"68""",Southpaw,"Aug 19, 1988",http://ufcstats.com/fighter-details/016a8d958883167c
 Sabina Mazo,"5' 7""",125 lbs.,"70""",Orthodox,"Mar 25, 1997",http://ufcstats.com/fighter-details/70d2329a92864fdb
+Francesco Mazzeo,"6' 3""",205 lbs.,"75""",Orthodox,"Sep 23, 1997",http://ufcstats.com/fighter-details/7b3c13fe33556a21
 Scott McAfee,"5' 8""",155 lbs.,--,Orthodox,"Aug 23, 1983",http://ufcstats.com/fighter-details/7e7d81bf162a5ec1
 Bobby McAndrews,--,--,--,Orthodox,--,http://ufcstats.com/fighter-details/ef6f45095119d416
 Michael McBride,"6' 1""",155 lbs.,--,Orthodox,"Mar 09, 1986",http://ufcstats.com/fighter-details/443f60bec7c3c3d5
 Ian McCall,"5' 5""",125 lbs.,"64""",Orthodox,"May 07, 1984",http://ufcstats.com/fighter-details/701e057d63c124d9
-Molly McCann,"5' 4""",125 lbs.,"62""",Orthodox,"May 04, 1990",http://ufcstats.com/fighter-details/51018a31ddf31eb2
+Molly McCann,"5' 4""",115 lbs.,"62""",Orthodox,"May 04, 1990",http://ufcstats.com/fighter-details/51018a31ddf31eb2
 Charles McCarthy,"5' 10""",185 lbs.,"71""",Orthodox,"Aug 06, 1980",http://ufcstats.com/fighter-details/da97d6c97d09c030
 Sean McCorkle,"6' 7""",265 lbs.,"81""",Orthodox,"Jul 17, 1976",http://ufcstats.com/fighter-details/008dc37cca279def
+Danni McCormack,"5' 4""",125 lbs.,"62""",Southpaw,"Mar 15, 1990",http://ufcstats.com/fighter-details/2a9f9db24cd032ba
 Kris McCray,"6' 0""",170 lbs.,"76""",Orthodox,"Sep 24, 1981",http://ufcstats.com/fighter-details/baed16f18348908e
 Tamdan McCrory,"6' 4""",185 lbs.,"76""",Switch,"Nov 05, 1986",http://ufcstats.com/fighter-details/eff47295daf721a6
 Rob McCullough,"5' 9""",155 lbs.,"69""",Orthodox,"May 26, 1977",http://ufcstats.com/fighter-details/11e3fd7546359fc5
@@ -2108,6 +2417,7 @@ Drew McFedries,"6' 0""",185 lbs.,"72""",Southpaw,"Jul 27, 1978",http://ufcstats.
 Liam McGeary,"6' 6""",205 lbs.,--,,"Oct 04, 1982",http://ufcstats.com/fighter-details/e4e0993befecdaf8
 Gan McGee,"6' 10""",265 lbs.,--,Orthodox,"Nov 20, 1976",http://ufcstats.com/fighter-details/d90b630e0561818b
 Court McGee,"5' 11""",170 lbs.,"75""",Orthodox,"Dec 12, 1984",http://ufcstats.com/fighter-details/523fa774700d7d3f
+Marcus McGhee,"5' 8""",135 lbs.,"69""",Orthodox,"May 07, 1990",http://ufcstats.com/fighter-details/c0ac37a4a1133da9
 Ryan McGillivray,"5' 11""",170 lbs.,--,,"Sep 27, 1986",http://ufcstats.com/fighter-details/1f9c371c93dfd3a9
 Ryan McGivern,"6' 0""",185 lbs.,--,Orthodox,"Jan 17, 1980",http://ufcstats.com/fighter-details/856ec65948b7d234
 Jack McGlaughlin,--,--,--,Orthodox,--,http://ufcstats.com/fighter-details/237187ed9f419285
@@ -2116,7 +2426,7 @@ Greg McIntyre,"5' 10""",155 lbs.,--,Orthodox,"Apr 21, 1980",http://ufcstats.com/
 Antonio McKee,"5' 8""",155 lbs.,--,Southpaw,"Mar 12, 1970",http://ufcstats.com/fighter-details/3414b50b08a10600
 AJ McKee,"5' 10""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/f3ec0214794a699e
 Rhys McKee,"6' 2""",170 lbs.,"78""",Orthodox,"Sep 10, 1995",http://ufcstats.com/fighter-details/f748267c4ab6c127
-Cory McKenna,"5' 3""",115 lbs.,"58""",Orthodox,"Nov 07, 1999",http://ufcstats.com/fighter-details/3351aa64aa83c4d9
+Cory McKenna,"5' 3""",115 lbs.,"58""",Orthodox,"Jul 11, 1999",http://ufcstats.com/fighter-details/3351aa64aa83c4d9
 Tim McKenzie,"6' 0""",185 lbs.,"74""",Orthodox,"Jul 21, 1982",http://ufcstats.com/fighter-details/9ca265dfe8323db3
 Cody McKenzie,"6' 0""",155 lbs.,"72""",Switch,"Dec 16, 1987",http://ufcstats.com/fighter-details/7be63795363029e8
 Terrance McKinney,"5' 10""",155 lbs.,"73""",Switch,"Sep 15, 1994",http://ufcstats.com/fighter-details/809bd1a871491508
@@ -2124,6 +2434,7 @@ Brian McLaughlin,"5' 9""",155 lbs.,--,,"May 12, 1984",http://ufcstats.com/fighte
 Jason McLean,"5' 5""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/8336d7a85ce45481
 Garreth McLellan,"6' 1""",185 lbs.,"72""",Southpaw,"Sep 01, 1982",http://ufcstats.com/fighter-details/f215cfbd4ba3c270
 Sara McMann,"5' 6""",135 lbs.,"66""",Orthodox,"Sep 24, 1980",http://ufcstats.com/fighter-details/7be74a12d7352df2
+Tommy McMillen,--,145 lbs.,--,,"Dec 15, 1997",http://ufcstats.com/fighter-details/6b0a6def604de298
 James McSweeney,"6' 4""",230 lbs.,"77""",Switch,"Oct 24, 1980",http://ufcstats.com/fighter-details/cac08b8685387ca5
 Charles McTorry,--,--,--,,--,http://ufcstats.com/fighter-details/acd8a53f7c0ce85e
 Daniel McWilliams,"6' 1""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/7b03d9df5910917d
@@ -2131,9 +2442,11 @@ Tim Means,"6' 2""",170 lbs.,"75""",Orthodox,"Feb 20, 1984",http://ufcstats.com/f
 Yancy Medeiros,"5' 10""",155 lbs.,"75""",Orthodox,"Sep 07, 1987",http://ufcstats.com/fighter-details/813550bc53b15fb0
 Anistavio Medeiros,"5' 6""",145 lbs.,--,Orthodox,"May 01, 1988",http://ufcstats.com/fighter-details/2937cb502dda0808
 Kaline Medeiros,"5' 3""",115 lbs.,--,,--,http://ufcstats.com/fighter-details/263af068bd986548
-Uros Medic,"6' 1""",155 lbs.,"71""",Southpaw,"Apr 25, 1993",http://ufcstats.com/fighter-details/681399317dbf4701
+MarQuel Mederos,"5' 10""",155 lbs.,"69""",Orthodox,"Nov 30, 1996",http://ufcstats.com/fighter-details/e2be0c1a9b886d92
+Uros Medic,"6' 1""",170 lbs.,"71""",Southpaw,"Apr 25, 1993",http://ufcstats.com/fighter-details/681399317dbf4701
 Todd Medina,"5' 10""",193 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/b60391da771deefe
 Jason Medina,"5' 9""",180 lbs.,--,,--,http://ufcstats.com/fighter-details/f53fb9d9e57cc38e
+Jose Daniel Medina,"6' 0""",185 lbs.,"74""",Orthodox,"May 17, 1991",http://ufcstats.com/fighter-details/baa9be02c3e3e038
 Emil Meek,"5' 11""",170 lbs.,"74""",Switch,"Aug 20, 1988",http://ufcstats.com/fighter-details/103b06d8707895a9
 Sanford Alton Meeks,"6' 5""",265 lbs.,"75""",Orthodox,"Apr 05, 1994",http://ufcstats.com/fighter-details/27c59ac201539d10
 Gerald Meerschaert,"6' 1""",185 lbs.,"77""",Southpaw,"Dec 18, 1987",http://ufcstats.com/fighter-details/6ac9bc2953c47345
@@ -2145,6 +2458,7 @@ Bryce Mejia,"6' 1""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/6eae26c
 Brian Melancon,"5' 8""",170 lbs.,--,Orthodox,"May 28, 1982",http://ufcstats.com/fighter-details/eee7dafac7d672b5
 Brandon Melendez,"5' 11""",155 lbs.,--,Southpaw,"Mar 24, 1983",http://ufcstats.com/fighter-details/2b06b6ad5db63348
 Gilbert Melendez,"5' 9""",145 lbs.,"73""",Orthodox,"Apr 12, 1982",http://ufcstats.com/fighter-details/aa5b4eff51bdc7d1
+Nair Melikyan,"5' 6""",155 lbs.,--,,"Aug 08, 1997",http://ufcstats.com/fighter-details/64b8561624d3b15e
 Marcelo Mello,"5' 7""",170 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/672ef06fd9f41f7d
 Fabio Mello,"5' 5""",155 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/8a028648f3f0761d
 Vanessa Melo,"5' 5""",135 lbs.,"65""",Orthodox,"Mar 27, 1988",http://ufcstats.com/fighter-details/9b7dfb3b7d99926a
@@ -2152,6 +2466,7 @@ Antonio Mendes,"6' 3""",205 lbs.,"77""",Southpaw,"Apr 19, 1981",http://ufcstats.
 Chad Mendes,"5' 6""",145 lbs.,"66""",Orthodox,"May 01, 1985",http://ufcstats.com/fighter-details/b5b684eac99ae0a3
 Augusto Mendes,"5' 6""",135 lbs.,"65""",Orthodox,"Mar 03, 1983",http://ufcstats.com/fighter-details/3d5b1ce6097dbb49
 Eddie Mendez,"5' 10""",185 lbs.,--,,"Jan 16, 1984",http://ufcstats.com/fighter-details/49e49b54e5901d0d
+Mateus Mendonca,"5' 6""",125 lbs.,"71""",Orthodox,"Jan 17, 1999",http://ufcstats.com/fighter-details/48812daf291a4e23
 Luis Mendoza,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/28200bc87367614f
 Pietro Menga,"5' 7""",125 lbs.,"68""",Southpaw,"Feb 15, 1988",http://ufcstats.com/fighter-details/869d68b5383131fd
 Alonzo Menifield,"6' 0""",205 lbs.,"76""",Orthodox,"Oct 18, 1987",http://ufcstats.com/fighter-details/a495f599e787614f
@@ -2160,13 +2475,15 @@ Dave Menne,"5' 10""",170 lbs.,--,Orthodox,"Jul 29, 1974",http://ufcstats.com/fig
 Steve Mensing,"5' 11""",185 lbs.,--,Orthodox,"Dec 06, 1977",http://ufcstats.com/fighter-details/3bc27ec15facbcf3
 Buck Meredith,"6' 2""",185 lbs.,--,,"May 17, 1982",http://ufcstats.com/fighter-details/36120738148f203f
 Adam Meredith,"6' 2""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/c1135a6892e916db
+Nick Meregali,--,--,--,,--,http://ufcstats.com/fighter-details/2f6dc878d653c442
 Joe Merritt,"6' 0""",170 lbs.,--,Orthodox,"Mar 07, 1984",http://ufcstats.com/fighter-details/e82d5f54daa85a7e
 Jeremiah Metcalf,"6' 1""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/5bdcbd8dd681a257
 Jonathan Meunier,"6' 3""",170 lbs.,--,Switch,"Aug 04, 1987",http://ufcstats.com/fighter-details/5823ceab56741617
 Yaotzin Meza,"5' 9""",145 lbs.,"71""",Orthodox,"Feb 04, 1981",http://ufcstats.com/fighter-details/3623bd267a2eef2e
 Guy Mezger,"6' 1""",200 lbs.,--,Orthodox,"Jan 01, 1968",http://ufcstats.com/fighter-details/946f341df6472ee0
+Jonathan Micallef,"6' 0""",170 lbs.,"77""",Southpaw,"Mar 05, 1999",http://ufcstats.com/fighter-details/f782f953bfe7b5f2
 Brandon Michaels,"5' 9""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/f5e4ce11afbdfb61
-Andreas Michailidis,"6' 0""",185 lbs.,"76""",Orthodox,"Jul 18, 1988",http://ufcstats.com/fighter-details/79325a3c1a5c3bf4
+Andreas Michailidis,"6' 0""",170 lbs.,"76""",Orthodox,"Jul 18, 1988",http://ufcstats.com/fighter-details/79325a3c1a5c3bf4
 David Michaud,"5' 9""",155 lbs.,--,Orthodox,"Nov 10, 1988",http://ufcstats.com/fighter-details/49f4b511932f71e9
 Chris Mickle,"5' 9""",145 lbs.,--,Orthodox,"Jul 10, 1983",http://ufcstats.com/fighter-details/f903967fd320da38
 Zachary Micklewright,"6' 0""",155 lbs.,"74""",Southpaw,"Aug 21, 1976",http://ufcstats.com/fighter-details/a36a14985a57a1c6
@@ -2187,6 +2504,7 @@ Henry Miller,"5' 7""",270 lbs.,--,Southpaw,"Jul 16, 1969",http://ufcstats.com/fi
 Micah Miller,"6' 0""",145 lbs.,--,Orthodox,"Feb 14, 1987",http://ufcstats.com/fighter-details/3ff0d0dc7a14bb50
 Aaron Miller,"5' 9""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/a4d055f1435d6d75
 Mo Miller,"5' 8""",135 lbs.,"72""",Orthodox,"Aug 10, 1992",http://ufcstats.com/fighter-details/39019970ac8543e9
+Juliana Miller,"5' 7""",125 lbs.,"66""",Orthodox,"May 07, 1996",http://ufcstats.com/fighter-details/aa0c573da7119292
 Eddy Millis,"6' 1""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/f2c934689243fe4e
 Che Mills,"6' 1""",170 lbs.,"76""",Orthodox,"Sep 29, 1982",http://ufcstats.com/fighter-details/6cadfd8f1d9e7685
 Adam Milstead,"6' 3""",205 lbs.,"76""",Orthodox,"Jul 03, 1987",http://ufcstats.com/fighter-details/72ffecf712673af1
@@ -2201,6 +2519,7 @@ Frank Mir,"6' 3""",264 lbs.,"79""",Southpaw,"May 24, 1979",http://ufcstats.com/f
 Juan Miranda,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/be8ad887e4d674b0
 Mario Miranda,"6' 3""",185 lbs.,"74""",Orthodox,"Jul 12, 1979",http://ufcstats.com/fighter-details/df2bf09c99594848
 Vitor Miranda,"6' 1""",185 lbs.,"77""",Orthodox,"Mar 10, 1979",http://ufcstats.com/fighter-details/4bcb6eb12b4ad4aa
+Gabriel Miranda,"5' 11""",145 lbs.,"71""",Orthodox,"Mar 25, 1990",http://ufcstats.com/fighter-details/b909a9a9688b5284
 Damir Mirenic,"6' 0""",185 lbs.,--,Orthodox,"Aug 02, 1974",http://ufcstats.com/fighter-details/992c82450d96f726
 Kazuo Misaki,"5' 8""",183 lbs.,--,Orthodox,"Apr 25, 1976",http://ufcstats.com/fighter-details/5e7a28f20927d64a
 Toby Misech,"5' 8""",145 lbs.,--,Southpaw,"Mar 07, 1988",http://ufcstats.com/fighter-details/3f87218a7aca84c4
@@ -2212,6 +2531,7 @@ Brad Mitchell,"5' 11""",145 lbs.,--,,"Oct 10, 1974",http://ufcstats.com/fighter-
 Clay Mitchell,"6' 2""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/3d960455f880bb25
 Bryce Mitchell,"5' 10""",145 lbs.,"70""",Southpaw,"Oct 04, 1994",http://ufcstats.com/fighter-details/d9c6f19f958643e9
 Maurice Mitchell,"5' 9""",145 lbs.,--,Orthodox,"Jun 29, 1987",http://ufcstats.com/fighter-details/568bebed6366b667
+Terrence Mitchell,"5' 10""",135 lbs.,"74""",Orthodox,"Dec 30, 1989",http://ufcstats.com/fighter-details/f3ca6908f78efebe
 Roman Mitichyan,"5' 10""",170 lbs.,--,Orthodox,"Sep 04, 1978",http://ufcstats.com/fighter-details/2961be02cfb0d2c1
 Matt Mitrione,"6' 3""",265 lbs.,"82""",Switch,"Jul 15, 1978",http://ufcstats.com/fighter-details/ba280572acfba13f
 Eiji Mitsuoka,"5' 7""",145 lbs.,--,Southpaw,"Jan 01, 1976",http://ufcstats.com/fighter-details/2b4faacc16d66898
@@ -2221,6 +2541,7 @@ Tomoya Miyashita,"5' 7""",139 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-de
 Kazuyuki Miyata,"5' 8""",139 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/af70d268e5352186
 Motoki Miyazawa,"5' 11""",168 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/9649d75defe0dedb
 Takeya Mizugaki,"5' 7""",135 lbs.,"69""",Orthodox,"Dec 16, 1983",http://ufcstats.com/fighter-details/48e093ea1f43a053
+Mizuki,"5' 3""",115 lbs.,"65""",Orthodox,"Aug 19, 1994",http://ufcstats.com/fighter-details/43a59ce3bb40449e
 Tatsuya Mizuno,"6' 1""",205 lbs.,--,Southpaw,"Jun 02, 1981",http://ufcstats.com/fighter-details/478c8706bdb92440
 Roxanne Modafferi,"5' 7""",125 lbs.,"69""",Orthodox,"Sep 24, 1982",http://ufcstats.com/fighter-details/4498b382c65a7faa
 Bobby Moffett,"5' 10""",145 lbs.,"73""",Orthodox,"Jun 01, 1990",http://ufcstats.com/fighter-details/d76ad9a08c4408ff
@@ -2228,7 +2549,7 @@ Bronson Mohika,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/65239fccec
 Nate Mohr,"5' 9""",155 lbs.,"72""",Orthodox,"Mar 03, 1983",http://ufcstats.com/fighter-details/04c15b52c3cc1cab
 Renato Moicano,"5' 11""",155 lbs.,"72""",Orthodox,"May 21, 1989",http://ufcstats.com/fighter-details/b6452706b373eea1
 Thiago Moises,"5' 9""",155 lbs.,"70""",Orthodox,"Mar 23, 1995",http://ufcstats.com/fighter-details/d945aae53e3e54e6
-Muhammad Mokaev,"5' 9""",125 lbs.,--,,"Jul 30, 2000",http://ufcstats.com/fighter-details/75353550928a7921
+Muhammad Mokaev,"5' 7""",125 lbs.,"70""",Orthodox,"Jul 30, 2000",http://ufcstats.com/fighter-details/75353550928a7921
 Ashkan Mokhtarian,"5' 6""",125 lbs.,"67""",Southpaw,"Sep 15, 1985",http://ufcstats.com/fighter-details/e9bc5748e6a76bb6
 Suman Mokhtarian,"5' 8""",145 lbs.,"72""",Orthodox,"Jun 13, 1992",http://ufcstats.com/fighter-details/192520689012c7e4
 Dan Molina,"5' 10""",216 lbs.,--,,"Jun 14, 1984",http://ufcstats.com/fighter-details/606136dee6f6ecea
@@ -2241,7 +2562,8 @@ Andrew Montanez,--,185 lbs.,--,,--,http://ufcstats.com/fighter-details/72c9c2ead
 Augusto Montano,"6' 1""",170 lbs.,"73""",Orthodox,"Oct 25, 1984",http://ufcstats.com/fighter-details/94508d80e1f885fc
 Erick Montano,"6' 0""",170 lbs.,"73""",Orthodox,"Nov 19, 1985",http://ufcstats.com/fighter-details/8163cd7de0342652
 Nicco Montano,"5' 5""",135 lbs.,"65""",Southpaw,"Dec 16, 1988",http://ufcstats.com/fighter-details/1de9ad94de18eeaf
-Alberto Montes,"5' 7""",135 lbs.,--,,"May 31, 1994",http://ufcstats.com/fighter-details/a112097ad877a48f
+Antonio Monteiro,"5' 7""",145 lbs.,"70""",Orthodox,"Jul 02, 1995",http://ufcstats.com/fighter-details/3e38b1ea16bd4d86
+Alberto Montes,"5' 7""",145 lbs.,"69""",Orthodox,"May 31, 1994",http://ufcstats.com/fighter-details/a112097ad877a48f
 Steve Montgomery,"6' 4""",185 lbs.,--,Southpaw,"Dec 19, 1990",http://ufcstats.com/fighter-details/6e92eb1242b46636
 James Moontasri,"5' 10""",170 lbs.,"71""",Switch,"Apr 10, 1988",http://ufcstats.com/fighter-details/c06a9b48d4132c8e
 Homer Moore,"5' 10""",205 lbs.,--,Orthodox,"Nov 27, 1971",http://ufcstats.com/fighter-details/e56df3c1d8b4b1cc
@@ -2258,7 +2580,7 @@ Leonardo Morales,"5' 8""",135 lbs.,--,Southpaw,"Dec 22, 1992",http://ufcstats.co
 Albert Morales,"5' 9""",135 lbs.,"72""",Orthodox,"May 25, 1991",http://ufcstats.com/fighter-details/544d7460b3e44393
 Joseph Morales,"5' 6""",125 lbs.,"69""",Switch,"Aug 22, 1994",http://ufcstats.com/fighter-details/2fe9032955c2e013
 Vince Morales,"5' 7""",135 lbs.,"70""",Orthodox,"Nov 12, 1990",http://ufcstats.com/fighter-details/37098a6e6c27fb66
-Omar Morales,"5' 11""",145 lbs.,"73""",Orthodox,"Oct 17, 1985",http://ufcstats.com/fighter-details/a0e6753c42698f13
+Omar Morales,"5' 11""",155 lbs.,"73""",Orthodox,"Oct 17, 1985",http://ufcstats.com/fighter-details/a0e6753c42698f13
 Michael Morales,"6' 0""",170 lbs.,"79""",Orthodox,"Jun 24, 1999",http://ufcstats.com/fighter-details/c32aeb1a59e6272d
 Sarah Moras,"5' 7""",135 lbs.,"67""",Orthodox,"Apr 30, 1988",http://ufcstats.com/fighter-details/539ed332b3078821
 Christian Morecraft,"6' 6""",260 lbs.,"81""",Orthodox,"Sep 08, 1986",http://ufcstats.com/fighter-details/80779d7441af1b52
@@ -2272,6 +2594,7 @@ Mike Moreno,"6' 0""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/bb2eee4
 Dan Moret,"6' 0""",155 lbs.,"73""",Southpaw,"Nov 21, 1986",http://ufcstats.com/fighter-details/66e98b3bb5fc5250
 Sammy Morgan,"5' 10""",170 lbs.,--,Orthodox,"Sep 28, 1981",http://ufcstats.com/fighter-details/2067a177a2842fbf
 Peggy Morgan,"6' 1""",135 lbs.,--,,"Dec 16, 1979",http://ufcstats.com/fighter-details/92b36014314b028b
+Alexander Morgan,"5' 10""",145 lbs.,"71""",Orthodox,"May 14, 1991",http://ufcstats.com/fighter-details/938ea36fe9c269f0
 Alex Morono,"5' 11""",170 lbs.,"72""",Orthodox,"Aug 16, 1990",http://ufcstats.com/fighter-details/cdb96af67d096b1e
 Maryna Moroz,"5' 7""",125 lbs.,"67""",Orthodox,"Sep 08, 1991",http://ufcstats.com/fighter-details/b4192a975027aab6
 Sergey Morozov,"5' 6""",135 lbs.,"67""",Orthodox,"Jun 14, 1989",http://ufcstats.com/fighter-details/2f6a993c7f547c13
@@ -2280,14 +2603,17 @@ Scott Morris,"5' 10""",210 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-detai
 Anthony Morrison,"5' 7""",145 lbs.,--,Orthodox,"Mar 29, 1984",http://ufcstats.com/fighter-details/dab0e6cb8c932162
 Jack Morrison,"5' 11""",205 lbs.,--,,--,http://ufcstats.com/fighter-details/38fccd44d669bb2f
 Harry Moskowitz,"6' 5""",275 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/4dc496aa0cfc0d95
+Carlos Mota,"5' 4""",125 lbs.,"69""",Orthodox,"Apr 15, 1995",http://ufcstats.com/fighter-details/b15862fcd6ded451
+Miki Motono,"5' 2""",115 lbs.,"63""",Southpaw,"May 18, 1994",http://ufcstats.com/fighter-details/a5fa51a81d0c5ed9
 Juan Mott,"6' 0""",190 lbs.,--,Switch,--,http://ufcstats.com/fighter-details/5da4e8dc02e50ac0
 Nikolas Motta,"5' 9""",155 lbs.,"70""",Orthodox,"Feb 08, 1993",http://ufcstats.com/fighter-details/37f560436d745c18
 Flavio Luiz Moura,"5' 11""",183 lbs.,--,Open Stance,--,http://ufcstats.com/fighter-details/ab35634d1a8c7a11
+Eduarda Moura,"5' 6""",125 lbs.,"66""",Orthodox,"Feb 28, 1994",http://ufcstats.com/fighter-details/de594b35c45c2e9a
 Gegard Mousasi,"6' 2""",185 lbs.,"76""",Orthodox,"Aug 01, 1985",http://ufcstats.com/fighter-details/232c582f29f8f65e
 Kris Moutinho,"5' 7""",135 lbs.,"68""",Southpaw,"Aug 09, 1992",http://ufcstats.com/fighter-details/9c27f3217891f3f0
 Kin Moy,"5' 5""",135 lbs.,--,,--,http://ufcstats.com/fighter-details/ae922e7d9e852d7a
 Jamie Moyle,"5' 1""",115 lbs.,"65""",Orthodox,"Mar 17, 1989",http://ufcstats.com/fighter-details/882d62561063a927
-Askar Mozharov,"6' 3""",205 lbs.,--,,"Oct 26, 1994",http://ufcstats.com/fighter-details/e92901944ce91909
+Askar Mozharov,"6' 3""",205 lbs.,"74""",Orthodox,"Oct 26, 1994",http://ufcstats.com/fighter-details/e92901944ce91909
 Garrett Mueller,"5' 9""",135 lbs.,--,,"Jan 29, 1989",http://ufcstats.com/fighter-details/d0c325dfefdde31f
 Lauren Mueller,"5' 5""",125 lbs.,"67""",Orthodox,"Nov 15, 1991",http://ufcstats.com/fighter-details/f923e012414c883e
 Belal Muhammad,"5' 11""",170 lbs.,"72""",Orthodox,"Jul 09, 1988",http://ufcstats.com/fighter-details/b1b0729d27936f2f
@@ -2296,6 +2622,7 @@ Quinn Mulhern,"6' 3""",155 lbs.,--,Orthodox,"Sep 20, 1984",http://ufcstats.com/f
 James Mulheron,"5' 10""",243 lbs.,"73""",Orthodox,"Feb 20, 1988",http://ufcstats.com/fighter-details/8d5350fa18b79e9a
 Jamie Mullarkey,"6' 0""",155 lbs.,"74""",Orthodox,"Aug 17, 1994",http://ufcstats.com/fighter-details/af9f42e6894047fc
 Jim Mullen,"6' 1""",215 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/1a49e0670dfaca31
+Melissa Mullins,"5' 7""",135 lbs.,"68""",Orthodox,"Jul 23, 1991",http://ufcstats.com/fighter-details/bd532e9a2b93870c
 Pedro Munhoz,"5' 6""",135 lbs.,"65""",Orthodox,"Sep 07, 1986",http://ufcstats.com/fighter-details/6bd02119599741a4
 Andre Muniz,"6' 1""",185 lbs.,"78""",Southpaw,"Feb 17, 1990",http://ufcstats.com/fighter-details/886264a0c9f4ea5e
 Mark Munoz,"6' 0""",185 lbs.,"71""",Orthodox,"Feb 09, 1978",http://ufcstats.com/fighter-details/179f1948dc234f1f
@@ -2307,7 +2634,9 @@ Makhmud Muradov,"6' 2""",185 lbs.,"75""",Orthodox,"Feb 08, 1990",http://ufcstats
 Kazunari Murakami,"6' 1""",220 lbs.,--,Orthodox,"Nov 29, 1973",http://ufcstats.com/fighter-details/cfbccfed4e4796fe
 Ryuichi Murata,"5' 8""",183 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/e3a6c6d6d0ac0815
 Kanako Murata,"5' 1""",115 lbs.,"62""",Orthodox,"Aug 10, 1993",http://ufcstats.com/fighter-details/e0b0cf71e0d69dd0
+Ailiya Muratbek,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/9b6dcc335ad03696
 Vince Murdock,"5' 6""",145 lbs.,"64""",Orthodox,"Mar 21, 1991",http://ufcstats.com/fighter-details/4b90384d7c3519b8
+Samandar Murodov,"6' 1""",170 lbs.,"75""",Orthodox,"Aug 28, 1999",http://ufcstats.com/fighter-details/6f4d199c0adc06f5
 Tom Murphy,"6' 2""",227 lbs.,--,Southpaw,"Nov 19, 1974",http://ufcstats.com/fighter-details/62918a2118de08b2
 Ian Murphy,"6' 1""",185 lbs.,--,Orthodox,"Jun 14, 1985",http://ufcstats.com/fighter-details/de25520d54eab12d
 Jon Murphy,"6' 3""",260 lbs.,--,Orthodox,"Aug 09, 1977",http://ufcstats.com/fighter-details/1b5c146ee7b86e34
@@ -2317,7 +2646,8 @@ Lerone Murphy,"5' 9""",145 lbs.,"73""",Orthodox,"Jul 22, 1991",http://ufcstats.c
 Lee Murray,"6' 3""",185 lbs.,--,Orthodox,"Sep 12, 1977",http://ufcstats.com/fighter-details/32016899d0a222a3
 Jesse Murray,"6' 3""",205 lbs.,"78""",Orthodox,"Jan 26, 1993",http://ufcstats.com/fighter-details/d0147e906106cd2e
 Khalid Murtazaliev,"6' 0""",185 lbs.,"76""",Orthodox,"Jul 15, 1993",http://ufcstats.com/fighter-details/231cae8b77fbbcc1
-Azamat Murzakanov,"5' 10""",225 lbs.,"71""",Southpaw,"Apr 12, 1989",http://ufcstats.com/fighter-details/e90a2f22417af68e
+Azamat Murzakanov,"5' 10""",205 lbs.,"71""",Southpaw,"Apr 12, 1989",http://ufcstats.com/fighter-details/e90a2f22417af68e
+Josias Musasa,"5' 8""",135 lbs.,"74""",Southpaw,"Oct 10, 1998",http://ufcstats.com/fighter-details/723b64c0e9a8f348
 Nicholas Musoke,"6' 0""",170 lbs.,"75""",Orthodox,"Apr 05, 1986",http://ufcstats.com/fighter-details/8b5f9ea38184ded3
 Andre Mussi,"6' 3""",242 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/d0d43cb9b14f231c
 Magomed Mustafaev,"5' 8""",155 lbs.,"71""",Orthodox,"Aug 02, 1988",http://ufcstats.com/fighter-details/31d7446b184e3305
@@ -2325,24 +2655,26 @@ Max Mustaki,"6' 0""",155 lbs.,--,Orthodox,"Nov 07, 1987",http://ufcstats.com/fig
 Elvis Mutapcic,"6' 0""",185 lbs.,"72""",Orthodox,"Jul 19, 1986",http://ufcstats.com/fighter-details/28c55b4087a6f136
 Fiona Muxlow,"5' 4""",145 lbs.,--,,"May 13, 1977",http://ufcstats.com/fighter-details/062e57ca1a3c95a8
 Ho Bae Myeon,"5' 11""",168 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/2719f300b0439039
-Na Liang,"5' 5""",115 lbs.,"67""",Orthodox,"Jul 27, 1996",http://ufcstats.com/fighter-details/ec0dcceace7d25a3
 Katsuhiko Nagata,"5' 7""",154 lbs.,--,Southpaw,"Oct 31, 1973",http://ufcstats.com/fighter-details/d5ae8074631762fc
 Yuji Nagata,"6' 0""",225 lbs.,--,Orthodox,"Apr 24, 1968",http://ufcstats.com/fighter-details/e49c2db95e572dc8
 Greg Nagy,"6' 1""",210 lbs.,--,Orthodox,"Oct 18, 1983",http://ufcstats.com/fighter-details/342422bb6ced1e8d
 Logan Nail,--,185 lbs.,--,,"Jun 20, 1989",http://ufcstats.com/fighter-details/47e0b5833e6bc91a
 Muhammad Naimov,"5' 9""",145 lbs.,"70""",Orthodox,"Aug 07, 1994",http://ufcstats.com/fighter-details/8d11d9c13e2ccdf7
 Yukiya Naito,"6' 1""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/7be328bb3c2ea22e
+Yura Naito,"6' 0""",185 lbs.,"74""",Orthodox,"Apr 26, 1996",http://ufcstats.com/fighter-details/50c469e0cb73be10
 Andrews Nakahara,"6' 1""",185 lbs.,--,Orthodox,"Mar 12, 1983",http://ufcstats.com/fighter-details/7a9ca95a92d7b64c
 Rin Nakai,"5' 1""",135 lbs.,--,Orthodox,"Oct 22, 1986",http://ufcstats.com/fighter-details/f9ae6914f604aa9f
 Kazuhiro Nakamura,"5' 11""",205 lbs.,"70""",Orthodox,"Jul 16, 1979",http://ufcstats.com/fighter-details/b034747dc1d15491
 Keita Nakamura,"5' 11""",170 lbs.,"73""",Southpaw,"May 22, 1984",http://ufcstats.com/fighter-details/65ddc8a9ac4e8531
 Daisuke Nakamura,"5' 7""",154 lbs.,--,Orthodox,"Jun 10, 1980",http://ufcstats.com/fighter-details/a196332ee4aa8a82
 Yusaku Nakamura,"5' 5""",145 lbs.,--,,"Jun 21, 1986",http://ufcstats.com/fighter-details/03e8df49c4a059ba
+Rinya Nakamura,"5' 7""",135 lbs.,"68""",Southpaw,"Mar 23, 1995",http://ufcstats.com/fighter-details/d8c811df0386d5e8
+Tokitaka Nakanishi,"5' 6""",135 lbs.,"66""",Orthodox,"Jul 28, 1996",http://ufcstats.com/fighter-details/eb9446a4f44e19cf
 Jutaro Nakao,"5' 9""",170 lbs.,--,Southpaw,"Nov 30, 1970",http://ufcstats.com/fighter-details/95eb112a85601a0a
 Yoshihiro Nakao,"6' 0""",220 lbs.,--,Southpaw,"Jun 25, 1972",http://ufcstats.com/fighter-details/e18012194473e8b0
 Yui Chul Nam,"5' 9""",145 lbs.,--,Orthodox,"Jul 16, 1981",http://ufcstats.com/fighter-details/a00ec21cfbba17b6
 Tyson Nam,"5' 7""",125 lbs.,"68""",Orthodox,"Oct 06, 1983",http://ufcstats.com/fighter-details/6e00cfffd54653c4
-Rose Namajunas,"5' 5""",115 lbs.,"65""",Orthodox,"Jun 29, 1992",http://ufcstats.com/fighter-details/47b63240018d5d86
+Rose Namajunas,"5' 5""",125 lbs.,"65""",Orthodox,"Jun 29, 1992",http://ufcstats.com/fighter-details/47b63240018d5d86
 Yasuhito Namekawa,"5' 9""",205 lbs.,--,Orthodox,"Oct 27, 1974",http://ufcstats.com/fighter-details/6083f497c22cc075
 Nad Narimani,"5' 8""",145 lbs.,"70""",Orthodox,"Apr 14, 1987",http://ufcstats.com/fighter-details/776a58a67665a171
 Roger Narvaez,"6' 3""",185 lbs.,--,Southpaw,"Sep 09, 1983",http://ufcstats.com/fighter-details/3a12a2f096a6d975
@@ -2354,12 +2686,12 @@ Reza Nasri,"5' 11""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details
 Nasrudin Nasrudinov,"6' 0""",205 lbs.,"71""",Orthodox,"Oct 06, 1991",http://ufcstats.com/fighter-details/769fa803bf9d2e3b
 Pawel Nastula,"6' 0""",230 lbs.,--,Southpaw,"Jun 26, 1970",http://ufcstats.com/fighter-details/154a6b3ffae264cd
 Rafael Natal,"6' 0""",185 lbs.,"77""",Orthodox,"Dec 25, 1982",http://ufcstats.com/fighter-details/0dba4df5f34d5ff0
-Kevin Natividad,"5' 6""",145 lbs.,"70""",Orthodox,"Apr 02, 1993",http://ufcstats.com/fighter-details/0c258d1d8e16e5f1
-Ismail Naurdiev,"5' 10""",170 lbs.,"74""",Orthodox,"Aug 18, 1996",http://ufcstats.com/fighter-details/6a96ad1bc34fb113
+Kevin Natividad,"5' 6""",135 lbs.,"70""",Orthodox,"Apr 02, 1993",http://ufcstats.com/fighter-details/0c258d1d8e16e5f1
+Ismail Naurdiev,"5' 10""",185 lbs.,"74""",Orthodox,"Aug 18, 1996",http://ufcstats.com/fighter-details/6a96ad1bc34fb113
 Danny Navarro,"5' 10""",155 lbs.,--,,"May 27, 1983",http://ufcstats.com/fighter-details/618f72750ec50b05
 Marcio Navarro,"6' 0""",155 lbs.,--,,"Sep 17, 1978",http://ufcstats.com/fighter-details/52f7d300738961ac
-Tafon Nchukwi,"6' 0""",205 lbs.,"77""",Orthodox,"Oct 14, 1994",http://ufcstats.com/fighter-details/6aae253467e8f9ce
-Dustin Neace,"5' 9""",145 lbs.,--,,"Sep 12, 1986",http://ufcstats.com/fighter-details/e503aa5c252a1b4d
+Tafon Nchukwi,"6' 0""",185 lbs.,"77""",Orthodox,"Oct 14, 1994",http://ufcstats.com/fighter-details/6aae253467e8f9ce
+Dustin Neace,"5' 9""",145 lbs.,"69""",,"Sep 12, 1986",http://ufcstats.com/fighter-details/e503aa5c252a1b4d
 Josh Neal,"6' 0""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/0b534765dca35e71
 Joe Neal,"5' 6""",135 lbs.,--,,"Jul 29, 1986",http://ufcstats.com/fighter-details/5751267660c734cb
 Geoff Neal,"5' 11""",170 lbs.,"75""",Southpaw,"Aug 28, 1990",http://ufcstats.com/fighter-details/b997be68943010fc
@@ -2370,10 +2702,11 @@ Steve Nelmark,"6' 0""",240 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-detai
 Shane Nelson,"5' 9""",155 lbs.,"70""",Southpaw,"Nov 29, 1984",http://ufcstats.com/fighter-details/2db7fa8db6bc9632
 Roy Nelson,"6' 0""",263 lbs.,"73""",Orthodox,"Jun 20, 1976",http://ufcstats.com/fighter-details/3f7c14c7eca7195d
 Gunnar Nelson,"5' 11""",170 lbs.,"72""",Switch,"Jul 28, 1988",http://ufcstats.com/fighter-details/fd55393021a8c255
-Kyle Nelson,"5' 11""",155 lbs.,"71""",Switch,"Apr 20, 1991",http://ufcstats.com/fighter-details/31f8081c7600da93
+Kyle Nelson,"5' 11""",145 lbs.,"71""",Switch,"Apr 20, 1991",http://ufcstats.com/fighter-details/31f8081c7600da93
 Lissette Neri,"5' 2""",145 lbs.,--,,"Aug 05, 1987",http://ufcstats.com/fighter-details/f4db63258ecf0613
 Mario Neto,"6' 0""",229 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/1209b5134401ca53
 Antonio Braga Neto,"6' 3""",185 lbs.,"77""",Orthodox,"Oct 29, 1987",http://ufcstats.com/fighter-details/fae67903c4fe636b
+Eduardo Neves,"6' 2""",263 lbs.,"78""",Orthodox,"Mar 16, 2000",http://ufcstats.com/fighter-details/1d688fa375d9431c
 Julio Cesar Neves Jr.,"5' 8""",145 lbs.,--,,"Apr 25, 1994",http://ufcstats.com/fighter-details/195d0d3e14a2e256
 Nick Newell,"5' 10""",155 lbs.,--,Southpaw,"Mar 17, 1986",http://ufcstats.com/fighter-details/f562238becb9ec50
 Journey Newson,"5' 5""",135 lbs.,"67""",Orthodox,"Mar 07, 1989",http://ufcstats.com/fighter-details/78f485f851891d68
@@ -2384,21 +2717,25 @@ Francis Ngannou,"6' 4""",250 lbs.,"83""",Orthodox,"Sep 05, 1986",http://ufcstats
 Ben Nguyen,"5' 5""",125 lbs.,"65""",Switch,"Aug 03, 1988",http://ufcstats.com/fighter-details/840d2c82ea68b9aa
 Steven Nguyen,"5' 11""",145 lbs.,"73""",Switch,"May 19, 1993",http://ufcstats.com/fighter-details/69037fc7730e4225
 Alex Nicholson,"6' 4""",185 lbs.,"77""",Orthodox,"May 02, 1990",http://ufcstats.com/fighter-details/2b6d855c6e280fb1
+Bo Nickal,"6' 1""",185 lbs.,"76""",Southpaw,"Jan 14, 1996",http://ufcstats.com/fighter-details/35673bf5204524ee
 Mike Nickels,"6' 4""",205 lbs.,--,Orthodox,"Dec 13, 1971",http://ufcstats.com/fighter-details/330ec26453c44a59
 Matheus Nicolau,"5' 6""",125 lbs.,"66""",Orthodox,"Jan 06, 1993",http://ufcstats.com/fighter-details/1a31ef98efce7a79
+Stewart Nicoll,"5' 5""",125 lbs.,"65""",Orthodox,"Nov 04, 1994",http://ufcstats.com/fighter-details/2bd98ab77a8daa75
 Jaimelene Nievera,"5' 5""",125 lbs.,--,Orthodox,"Oct 28, 1984",http://ufcstats.com/fighter-details/3edf45e1717fa764
 Khomkrit Niimi,"5' 2""",125 lbs.,--,,--,http://ufcstats.com/fighter-details/52a003d768f10d91
 Tom Niinimaki,"5' 9""",145 lbs.,"69""",Orthodox,"Jul 25, 1982",http://ufcstats.com/fighter-details/5fceb45939fc0c8a
 Ramsey Nijem,"5' 11""",155 lbs.,"75""",Orthodox,"Apr 01, 1988",http://ufcstats.com/fighter-details/22aa91e402d0fe1f
 Hans Nijman,"6' 0""",250 lbs.,--,Switch,"Oct 23, 1959",http://ufcstats.com/fighter-details/4956f60b7fa57c1a
+Fedor Nikolov,--,--,--,,--,http://ufcstats.com/fighter-details/346f789951e85f3f
 Jack Nilson,--,--,--,,--,http://ufcstats.com/fighter-details/53e533db1b8e9712
 Mats Nilsson,"6' 1""",170 lbs.,--,Orthodox,"Dec 05, 1983",http://ufcstats.com/fighter-details/a9bcf8717dd12532
 Guangyou Ning,"5' 4""",145 lbs.,"64""",Southpaw,"Dec 15, 1981",http://ufcstats.com/fighter-details/2c1170b825f58e57
 Soichi Nishida,"5' 11""",320 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/6810d8d2dd557cf9
 Yosuke Nishijima,"5' 9""",205 lbs.,--,Orthodox,"May 15, 1973",http://ufcstats.com/fighter-details/5cde96e0a1a1fffe
+Yamato Nishikawa,"5' 7""",155 lbs.,--,Orthodox,"Dec 06, 2002",http://ufcstats.com/fighter-details/7beecbe0a08cf002
 Akiyo Nishiura,"5' 8""",139 lbs.,--,Southpaw,"Aug 08, 1983",http://ufcstats.com/fighter-details/6c9383ffab2725a5
 Anthony Njokuani,"6' 1""",155 lbs.,"75""",Orthodox,"Mar 01, 1980",http://ufcstats.com/fighter-details/6bf5a7d3e081ade2
-Chidi Njokuani,"6' 3""",185 lbs.,"80""",Orthodox,"Dec 31, 1988",http://ufcstats.com/fighter-details/c68c68efaa5ca6ef
+Chidi Njokuani,"6' 3""",170 lbs.,"80""",Orthodox,"Dec 31, 1988",http://ufcstats.com/fighter-details/c68c68efaa5ca6ef
 Derrick Noble,"5' 9""",170 lbs.,--,Southpaw,"Aug 14, 1978",http://ufcstats.com/fighter-details/21321cdfba797c52
 Kyle Noblitt,"6' 2""",243 lbs.,--,,"Dec 26, 1989",http://ufcstats.com/fighter-details/4acf03bdec2025d7
 Pedro Nobre,"5' 5""",135 lbs.,--,,"Feb 13, 1986",http://ufcstats.com/fighter-details/e983c62faf677ab2
@@ -2408,24 +2745,28 @@ Rogerio Nogueira,"6' 2""",205 lbs.,"75""",Southpaw,"Jun 02, 1976",http://ufcstat
 Alexandre Franca Nogueira,"5' 7""",145 lbs.,--,Orthodox,"Jan 15, 1978",http://ufcstats.com/fighter-details/4c27ca8c8481f79a
 Talita Nogueira,"5' 10""",145 lbs.,--,,"Oct 13, 1985",http://ufcstats.com/fighter-details/a3d1d060f9af97fe
 Kyle Noke,"6' 1""",170 lbs.,"76""",Southpaw,"Mar 18, 1980",http://ufcstats.com/fighter-details/7339d340aa2889cb
+Tom Nolan,"6' 3""",155 lbs.,"73""",Southpaw,"Mar 08, 2000",http://ufcstats.com/fighter-details/6c3b2525436cf5d4
 Nick Nolte,"6' 0""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/d665de9b4da87c22
 KJ Noons,"5' 10""",155 lbs.,"70""",Orthodox,"Dec 07, 1982",http://ufcstats.com/fighter-details/b7ffa72aa148599a
 Sage Northcutt,"6' 0""",170 lbs.,"71""",Orthodox,"Mar 01, 1996",http://ufcstats.com/fighter-details/ed9d8ee3a4239b1c
 Jan Nortje,"6' 1""",310 lbs.,--,Southpaw,"Apr 11, 1975",http://ufcstats.com/fighter-details/bd4389b71fdc0ce2
 Scott Norton,"5' 10""",170 lbs.,--,Orthodox,"Mar 15, 1973",http://ufcstats.com/fighter-details/f21a3d68fb9df387
+Shohei Nose,"5' 6""",135 lbs.,"68""",Switch,"Oct 19, 1997",http://ufcstats.com/fighter-details/6b0e83b094f816ac
 Jonatas Novaes,"5' 11""",170 lbs.,--,,"Mar 02, 1981",http://ufcstats.com/fighter-details/9e8e5c529057fe60
 Jason Novelli,"6' 0""",155 lbs.,--,Orthodox,"Jun 08, 1979",http://ufcstats.com/fighter-details/459e4dc69ec669b2
 Phillipe Nover,"5' 9""",145 lbs.,"72""",Orthodox,"Feb 03, 1984",http://ufcstats.com/fighter-details/64360e618823a8e4
+Taiyilake Nueraji,"6' 2""",170 lbs.,"75""",Southpaw,"Jan 12, 2001",http://ufcstats.com/fighter-details/7498b3ac79a3b948
 Shayilan Nuerdanbieke,"5' 8""",145 lbs.,"69""",Orthodox,"May 04, 1994",http://ufcstats.com/fighter-details/0a73acff6325c1e2
 Diego Nunes,"5' 6""",145 lbs.,"67""",Orthodox,"Nov 30, 1982",http://ufcstats.com/fighter-details/3a24769a4855040a
 Amanda Nunes,"5' 8""",135 lbs.,"69""",Orthodox,"May 30, 1988",http://ufcstats.com/fighter-details/80fa8218c99f9c58
-Nina Nunes,"5' 5""",115 lbs.,"64""",Orthodox,"Dec 03, 1985",http://ufcstats.com/fighter-details/d343df8ba11f4c4e
+Nina Nunes,"5' 5""",125 lbs.,"64""",Orthodox,"Dec 03, 1985",http://ufcstats.com/fighter-details/d343df8ba11f4c4e
 Istela Nunes,"5' 4""",115 lbs.,"66""",Orthodox,"Jul 23, 1992",http://ufcstats.com/fighter-details/efc67b07eed39794
 Josiane Nunes,"5' 2""",135 lbs.,"67""",Southpaw,"Dec 23, 1993",http://ufcstats.com/fighter-details/68d35296f566792b
+Diyar Nurgozhay,"6' 2""",205 lbs.,"74""",Southpaw,"Apr 22, 1997",http://ufcstats.com/fighter-details/709fadb644ee3f51
 Khabib Nurmagomedov,"5' 10""",155 lbs.,"70""",Orthodox,"Sep 20, 1988",http://ufcstats.com/fighter-details/032cc3922d871c7f
 Said Nurmagomedov,"5' 8""",135 lbs.,"70""",Orthodox,"Apr 05, 1992",http://ufcstats.com/fighter-details/0fd5f4b838e890cc
 Abubakar Nurmagomedov,"5' 11""",170 lbs.,"72""",Orthodox,"Nov 13, 1989",http://ufcstats.com/fighter-details/029e1293e609fd74
-Umar Nurmagomedov,"5' 8""",135 lbs.,--,Orthodox,"Mar 01, 1996",http://ufcstats.com/fighter-details/2b6fc1c02736833d
+Umar Nurmagomedov,"5' 8""",135 lbs.,"69""",Orthodox,"Jan 03, 1996",http://ufcstats.com/fighter-details/2b6fc1c02736833d
 Kennedy Nzechukwu,"6' 5""",205 lbs.,"83""",Southpaw,"Jun 13, 1992",http://ufcstats.com/fighter-details/8667caa0451d245b
 Jake O'Brien,"6' 3""",205 lbs.,"76""",Orthodox,"Sep 25, 1984",http://ufcstats.com/fighter-details/20bcc9966affb19c
 TJ O'Brien,"6' 2""",155 lbs.,--,Orthodox,"Jan 01, 1987",http://ufcstats.com/fighter-details/d25b93992f285953
@@ -2439,28 +2780,35 @@ Casey O'Neill,"5' 6""",125 lbs.,"69""",Orthodox,"Oct 07, 1997",http://ufcstats.c
 Brendan O'Reilly,"5' 7""",170 lbs.,"69""",Orthodox,"Jun 24, 1987",http://ufcstats.com/fighter-details/494b0bfdbac74502
 Takahiro Oba,"5' 8""",200 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/7139cd2ae4bf6a29
 Nobuhiro Obiya,"5' 8""",145 lbs.,--,Orthodox,"Jan 15, 1981",http://ufcstats.com/fighter-details/6e3282d57d2467a0
+Jose Ochoa,--,125 lbs.,--,,"Dec 31, 2000",http://ufcstats.com/fighter-details/88be62d6c1e6dadb
 Christian Ocon,"5' 8""",135 lbs.,"69""",Orthodox,"Feb 05, 1996",http://ufcstats.com/fighter-details/2d6d6ffe5a446ea2
 Richard Odoms,"6' 5""",265 lbs.,--,Orthodox,"May 08, 1975",http://ufcstats.com/fighter-details/f43907e75f8d9baa
 Volkan Oezdemir,"6' 2""",205 lbs.,"75""",Orthodox,"Sep 19, 1989",http://ufcstats.com/fighter-details/0845c81e37d3bcb3
+Kaan Ofli,"5' 7""",145 lbs.,"66""",Orthodox,"Jun 19, 1993",http://ufcstats.com/fighter-details/7facc9c45d792985
 Naoya Ogawa,"6' 4""",255 lbs.,--,Orthodox,"Mar 31, 1968",http://ufcstats.com/fighter-details/4b2390cfaceb91d8
+Trey Ogden,"5' 11""",155 lbs.,"72""",Orthodox,"Nov 14, 1989",http://ufcstats.com/fighter-details/cfc3e7bb44685289
 Andy Ogle,"5' 8""",145 lbs.,"69""",Orthodox,"Feb 16, 1989",http://ufcstats.com/fighter-details/b6c4451cb13c9303
+Ho Taek Oh,--,155 lbs.,--,,"Jul 20, 1993",http://ufcstats.com/fighter-details/5c020ee6ab450870
 Michiyoshi Ohara,"5' 10""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/6a8a06b542e1516d
 Koji Oishi,"5' 8""",170 lbs.,--,Orthodox,"May 31, 1977",http://ufcstats.com/fighter-details/01daf32100ed7517
 Takayuki Okada,"6' 1""",290 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/32541eb5d12668b4
 Yushin Okami,"6' 2""",170 lbs.,"75""",Southpaw,"Jul 21, 1981",http://ufcstats.com/fighter-details/acff437707625fc7
 JJ Okanovich,"5' 11""",155 lbs.,"76""",Orthodox,"Nov 04, 1990",http://ufcstats.com/fighter-details/aa40fe6038db56cb
+Bolaji Oki,"5' 10""",155 lbs.,"73""",Orthodox,"Nov 15, 1995",http://ufcstats.com/fighter-details/4bdedbdeedff7d1d
 Kazuki Okubo,"5' 11""",175 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/33454ad90754cb49
 Masakatsu Okuda,--,--,--,,--,http://ufcstats.com/fighter-details/02a65a55f25fb4f3
 Aleksei Oleinik,"6' 2""",240 lbs.,"80""",Orthodox,"Jun 20, 1977",http://ufcstats.com/fighter-details/98c23cb6da5b3352
-Michal Oleksiejczuk,"6' 0""",205 lbs.,"74""",Southpaw,"Feb 22, 1995",http://ufcstats.com/fighter-details/0d65c432720accb9
+Michal Oleksiejczuk,"6' 0""",185 lbs.,"74""",Southpaw,"Feb 22, 1995",http://ufcstats.com/fighter-details/0d65c432720accb9
 Rafaello Oliveira,"5' 8""",155 lbs.,"71""",Orthodox,"Jan 26, 1982",http://ufcstats.com/fighter-details/15b1b21cd743d652
 Charles Oliveira,"5' 10""",155 lbs.,"74""",Orthodox,"Oct 17, 1989",http://ufcstats.com/fighter-details/07225ba28ae309b6
 Jorge Oliveira,"6' 1""",205 lbs.,--,,--,http://ufcstats.com/fighter-details/bec2746f033802c3
 Ednaldo Oliveira,"6' 5""",205 lbs.,--,Orthodox,"Feb 19, 1984",http://ufcstats.com/fighter-details/acd9513399a8b09b
 Alex Oliveira,"5' 11""",170 lbs.,"76""",Orthodox,"Feb 21, 1988",http://ufcstats.com/fighter-details/57b10fca4f9c9a7a
-Maria Oliveira,"5' 5""",115 lbs.,"69""",Orthodox,"Dec 12, 1996",http://ufcstats.com/fighter-details/37d752ec41ed84bb
+Maria Oliveira,"5' 6""",115 lbs.,"69""",Orthodox,"Dec 12, 1996",http://ufcstats.com/fighter-details/37d752ec41ed84bb
 Bruno Oliveira,"6' 4""",205 lbs.,"80""",Orthodox,"May 02, 1984",http://ufcstats.com/fighter-details/1e85912c9bab7e2b
 Saimon Oliveira,"5' 4""",135 lbs.,"72""",Orthodox,"Apr 21, 1991",http://ufcstats.com/fighter-details/72ea1984c52019b5
+Vinicius Oliveira,"5' 9""",135 lbs.,"70""",Switch,"Nov 30, 1995",http://ufcstats.com/fighter-details/18d01f7f8338ae72
+Ravena Oliveira,"5' 5""",115 lbs.,"65""",Orthodox,"Feb 20, 1997",http://ufcstats.com/fighter-details/4948e412fa6ab67d
 Wendell Oliveira Marques,"5' 10""",170 lbs.,--,Orthodox,"Jun 01, 1983",http://ufcstats.com/fighter-details/32c03df3c9760069
 Felipe Olivieri,"5' 9""",155 lbs.,--,Orthodox,"Apr 12, 1985",http://ufcstats.com/fighter-details/948880beac71f028
 Andy Ologun,"6' 0""",154 lbs.,--,Orthodox,"Jun 12, 1983",http://ufcstats.com/fighter-details/e96d8538d3f9d0ed
@@ -2468,13 +2816,14 @@ Shana Olsen,"5' 7""",145 lbs.,--,,"Dec 17, 1980",http://ufcstats.com/fighter-det
 Casey Olson,"5' 7""",145 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/7613773461b276f4
 Dennis Olson,"6' 0""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/8e0709784259402d
 Cameron Olson,"6' 1""",205 lbs.,"75""",Orthodox,"Nov 22, 1989",http://ufcstats.com/fighter-details/5a9104718439ef44
-Gadzhi Omargadzhiev,"6' 1""",185 lbs.,"71""",Switch,"Feb 24, 1993",http://ufcstats.com/fighter-details/684d3aee255a3d09
+Gadzhi Omargadzhiev,"6' 1""",170 lbs.,"71""",Switch,"Feb 24, 1993",http://ufcstats.com/fighter-details/684d3aee255a3d09
 Alan Omer,"5' 10""",145 lbs.,--,Orthodox,"Sep 14, 1988",http://ufcstats.com/fighter-details/f2ad06f1007c481a
 Daniel Omielanczuk,"6' 0""",247 lbs.,"74""",Southpaw,"Aug 31, 1982",http://ufcstats.com/fighter-details/470fedbc8563ac47
 Michihiro Omigawa,"5' 6""",145 lbs.,"68""",Orthodox,"Dec 19, 1975",http://ufcstats.com/fighter-details/9f842be1a5337be6
-David Onama,"5' 11""",155 lbs.,"74""",Orthodox,"Jun 07, 1994",http://ufcstats.com/fighter-details/ffe9703408fb5964
-Charlie Ontiveros,"6' 2""",185 lbs.,"78""",Switch,"Jul 04, 1991",http://ufcstats.com/fighter-details/318572f6f74b760d
+David Onama,"5' 11""",145 lbs.,"74""",Orthodox,"Jun 07, 1994",http://ufcstats.com/fighter-details/ffe9703408fb5964
+Charlie Ontiveros,"6' 2""",155 lbs.,"74""",Switch,"Jul 04, 1991",http://ufcstats.com/fighter-details/318572f6f74b760d
 Chibwikem Onyenegecha,"6' 3""",185 lbs.,--,Orthodox,"Apr 18, 1994",http://ufcstats.com/fighter-details/887e09328cd63df1
+Myktybek Orolbai,"5' 10""",155 lbs.,"74""",Orthodox,"Feb 10, 1998",http://ufcstats.com/fighter-details/bf2c8e01b07d3eb1
 Sam Oropeza,"6' 2""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/6b8db407d49c6e4b
 Brian Ortega,"5' 8""",145 lbs.,"69""",Switch,"Feb 21, 1991",http://ufcstats.com/fighter-details/def8166ff24bd237
 Tito Ortiz,"6' 3""",205 lbs.,"74""",Orthodox,"Jan 23, 1975",http://ufcstats.com/fighter-details/2f732dd9210d301f
@@ -2489,6 +2838,7 @@ Rachael Ostovich,"5' 3""",125 lbs.,"62""",Orthodox,"Feb 25, 1991",http://ufcstat
 Pedro Otavio,"6' 3""",245 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/4512e46543b960ad
 Alexander Otsuka,"6' 1""",205 lbs.,--,Orthodox,"Jul 17, 1971",http://ufcstats.com/fighter-details/865aa315ea62c511
 Takafumi Otsuka,"5' 6""",139 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/6b8f28da9a483049
+Quemuel Ottoni,"6' 0""",155 lbs.,"72""",Orthodox,"Oct 22, 1992",http://ufcstats.com/fighter-details/7ce21433c2a53168
 Zak Ottow,"5' 11""",170 lbs.,"72""",Orthodox,"Dec 22, 1986",http://ufcstats.com/fighter-details/47cd337b86b1af92
 Artur Oumakhanov,"5' 7""",154 lbs.,--,Orthodox,"Feb 27, 1979",http://ufcstats.com/fighter-details/1ef0eae31904e534
 Sidney Outlaw,"5' 8""",170 lbs.,"74""",Orthodox,"Apr 11, 1992",http://ufcstats.com/fighter-details/871ce0b4a01922b6
@@ -2496,22 +2846,26 @@ Alistair Overeem,"6' 4""",265 lbs.,"80""",Orthodox,"May 17, 1980",http://ufcstat
 Valentijn Overeem,"6' 3""",230 lbs.,--,Orthodox,"Aug 17, 1976",http://ufcstats.com/fighter-details/20e403a1acfef130
 Craig Oxley,"5' 9""",155 lbs.,--,,"Feb 14, 1973",http://ufcstats.com/fighter-details/4bb9d7a32d02a03e
 Shungo Oyama,"5' 11""",185 lbs.,--,Southpaw,"Apr 11, 1974",http://ufcstats.com/fighter-details/47b7e4e60813b7b2
+Ren Ozaki,"5' 7""",135 lbs.,"68""",Orthodox,"Dec 15, 2001",http://ufcstats.com/fighter-details/8997ee20b6a43d76
 Alptekin Ozkilic,"5' 5""",125 lbs.,"65""",Orthodox,"Mar 27, 1986",http://ufcstats.com/fighter-details/e18a19001a3f7c7d
 Raquel Pa'aluhi,"5' 7""",135 lbs.,--,,--,http://ufcstats.com/fighter-details/373be586f370d400
 Nick Pace,"5' 7""",135 lbs.,"68""",Orthodox,"Apr 17, 1987",http://ufcstats.com/fighter-details/8cb76103cd8a1562
 Larissa Pacheco,"5' 7""",135 lbs.,--,Orthodox,"Sep 07, 1994",http://ufcstats.com/fighter-details/16b89be2f5c16fba
+Angel Pacheco,"5' 8""",135 lbs.,"70""",Orthodox,"Jan 13, 1992",http://ufcstats.com/fighter-details/07797f10b9569cfc
 Teemu Packalen,"6' 1""",155 lbs.,"75""",Orthodox,"May 22, 1987",http://ufcstats.com/fighter-details/8f4eeaf7a0df7c1a
 George Pacurariu,"5' 7""",135 lbs.,--,,"Jul 28, 1984",http://ufcstats.com/fighter-details/c51da79b0346b5b7
 Cyrillo Padilha,"5' 11""",155 lbs.,--,,"Jan 23, 1978",http://ufcstats.com/fighter-details/856c4d2668a875f9
 Gary Padilla,"5' 11""",205 lbs.,--,,"May 04, 1980",http://ufcstats.com/fighter-details/01dd4cdc2446f665
-Fernando Padilla,"6' 1""",155 lbs.,--,,"Dec 15, 1996",http://ufcstats.com/fighter-details/d2f43cfaf8ca3560
+Fernando Padilla,"6' 1""",145 lbs.,"76""",Orthodox,"Dec 15, 1996",http://ufcstats.com/fighter-details/d2f43cfaf8ca3560
+Chris Padilla,"5' 9""",155 lbs.,"74""",Orthodox,"Sep 14, 1995",http://ufcstats.com/fighter-details/06626b6287e1ae1e
 Damacio Page,"5' 6""",135 lbs.,"66""",Orthodox,"Sep 30, 1982",http://ufcstats.com/fighter-details/c96e2ae6021144a1
-Michael Page,"6' 2""",170 lbs.,--,,"Apr 07, 1987",http://ufcstats.com/fighter-details/a67d071163962af8
+Michael Page,"6' 3""",170 lbs.,"79""",Switch,"Apr 07, 1987",http://ufcstats.com/fighter-details/a67d071163962af8
 Dustin Pague,"5' 9""",135 lbs.,"74""",Orthodox,"Aug 05, 1987",http://ufcstats.com/fighter-details/55f80a8aeffcdb33
 Josh Paiva,"5' 6""",125 lbs.,--,,"Apr 05, 1991",http://ufcstats.com/fighter-details/1e12c1dbbb1e2dda
 Raulian Paiva,"5' 8""",135 lbs.,"69""",Orthodox,"Oct 17, 1995",http://ufcstats.com/fighter-details/82b4e942781b1046
 Dinis Paiva Jr.,"5' 9""",145 lbs.,"71""",Southpaw,"May 26, 1988",http://ufcstats.com/fighter-details/ad3a5e465c76e499
 Fredson Paixao,"5' 6""",145 lbs.,"66""",Orthodox,"May 13, 1979",http://ufcstats.com/fighter-details/320edfb0332b7073
+Luis Pajuelo,"5' 10""",145 lbs.,"69""",Orthodox,"Dec 18, 1994",http://ufcstats.com/fighter-details/e530df53922f413e
 Jose Palacios,"5' 9""",145 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/de20ffb3fc2e7629
 Ricky Palacios,"5' 6""",145 lbs.,--,Orthodox,"Jul 05, 1987",http://ufcstats.com/fighter-details/797ddccda75f169f
 Bart Palaszewski,"5' 9""",145 lbs.,"70""",Orthodox,"May 30, 1983",http://ufcstats.com/fighter-details/4304992c2acc187b
@@ -2521,6 +2875,8 @@ Rousimar Palhares,"5' 8""",170 lbs.,"71""",Orthodox,"Feb 26, 1980",http://ufcsta
 Tulio Palhares,--,180 lbs.,--,,--,http://ufcstats.com/fighter-details/e8c170a64dc920ac
 Stephen Palling,"5' 4""",143 lbs.,--,,"Jan 29, 1967",http://ufcstats.com/fighter-details/ab7c212de9f66af0
 Eduardo Pamplona,"5' 11""",170 lbs.,--,,"Feb 20, 1973",http://ufcstats.com/fighter-details/f31c0905045fa100
+Ruel Panales,"5' 5""",125 lbs.,"67""",Southpaw,"Dec 07, 1996",http://ufcstats.com/fighter-details/2742f028399bf8c7
+Yuri Panferov,"6' 1""",185 lbs.,"72""",Orthodox,"Aug 30, 1996",http://ufcstats.com/fighter-details/36d811b015635b67
 Alexandre Pantoja,"5' 5""",125 lbs.,"67""",Orthodox,"Apr 16, 1990",http://ufcstats.com/fighter-details/a0f0004aadf10b71
 Jared Papazian,"5' 8""",135 lbs.,"67""",Southpaw,"Feb 01, 1988",http://ufcstats.com/fighter-details/edad57b3dddf2168
 Kathryn Paprocki,"5' 3""",115 lbs.,"63""",Orthodox,"Apr 28, 1993",http://ufcstats.com/fighter-details/bd381cde8426077a
@@ -2531,25 +2887,34 @@ Ido Pariente,"5' 8""",155 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-detail
 Josh Parisian,"6' 4""",265 lbs.,"79""",Orthodox,"Jun 28, 1989",http://ufcstats.com/fighter-details/b5da8f7d05e85a55
 Karo Parisyan,"5' 10""",170 lbs.,"72""",Orthodox,"Aug 28, 1982",http://ufcstats.com/fighter-details/349aaa3da11eb587
 Won Sik Park,"5' 11""",154 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/9df394db5ca103eb
-Junyong Park,"5' 10""",185 lbs.,"73""",Orthodox,"Feb 27, 1991",http://ufcstats.com/fighter-details/285ae0b4a68221f4
+JunYong Park,"5' 10""",185 lbs.,"73""",Orthodox,"Feb 27, 1991",http://ufcstats.com/fighter-details/285ae0b4a68221f4
 Harvey Park,"6' 0""",155 lbs.,"70""",Orthodox,"Mar 22, 1986",http://ufcstats.com/fighter-details/b709b534b6873744
+HyunSung Park,"5' 7""",125 lbs.,"66""",Orthodox,"Nov 04, 1995",http://ufcstats.com/fighter-details/b671bdf981ad527d
+Jae Hyun Park,"5' 8""",155 lbs.,"72""",Orthodox,"Dec 12, 2001",http://ufcstats.com/fighter-details/fe1595732dfb08fc
 Norman Parke,"5' 11""",155 lbs.,"70""",Southpaw,"Dec 22, 1986",http://ufcstats.com/fighter-details/14ff46596ad80609
 Ryan Parker,"6' 3""",235 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/6a0b80a24f22e152
 Larry Parker,"5' 11""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/c0231720fe516994
 Tyra Parker,"5' 5""",115 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/64be3dc99eaa42b6
+Mick Parkin,"6' 4""",265 lbs.,"79""",Orthodox,"Oct 02, 1995",http://ufcstats.com/fighter-details/0d5cc0170c1a7e71
 Willie Parks,"5' 10""",185 lbs.,--,,"Nov 04, 1983",http://ufcstats.com/fighter-details/86ad0ae839331bd7
 Jordan Parsons,"5' 9""",145 lbs.,--,,"Aug 26, 1990",http://ufcstats.com/fighter-details/8b2a18d3c6735083
 Preston Parsons,"5' 11""",170 lbs.,"71""",Orthodox,"Jul 15, 1995",http://ufcstats.com/fighter-details/9fe7af8b3fbe00a0
 Jonny Parsons,"5' 9""",170 lbs.,"69""",Orthodox,"Sep 06, 1991",http://ufcstats.com/fighter-details/2975297f505e9447
 Onassis Parungao,"5' 11""",200 lbs.,--,,--,http://ufcstats.com/fighter-details/96d173b7f92aa520
+Ramona Pascual,"5' 7""",135 lbs.,"66""",Southpaw,"Sep 23, 1988",http://ufcstats.com/fighter-details/3eb4dc9a7d4ac906
+Billy Pasulatan,"5' 5""",125 lbs.,"66""",Switch,"Aug 07, 1991",http://ufcstats.com/fighter-details/e5a59983f4603621
 Jhonoven Pati,"6' 1""",185 lbs.,"75""",Switch,"Aug 29, 1990",http://ufcstats.com/fighter-details/6b16024d44eb03a2
+Windri Patilima,"5' 6""",155 lbs.,"71""",Southpaw,"Jul 19, 1993",http://ufcstats.com/fighter-details/66d42e9503fa108e
 Jorge Patino,"5' 8""",170 lbs.,--,Orthodox,"Aug 05, 1973",http://ufcstats.com/fighter-details/c8cca8f3de5be4b4
 Russell Patrick,"5' 9""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/eafedba0617ced81
 Claude Patrick,"5' 11""",170 lbs.,"75""",Orthodox,"Jun 14, 1980",http://ufcstats.com/fighter-details/56116a79e4deed06
 Alan Patrick,"5' 11""",155 lbs.,"74""",Southpaw,"Jul 19, 1983",http://ufcstats.com/fighter-details/cd7763bcadb5d4c8
 Michael Patt,"6' 0""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/83d0de122f2f9664
 Justin Patterson,"5' 10""",170 lbs.,--,,"Dec 07, 1985",http://ufcstats.com/fighter-details/2dc7c49cfaeb867c
+Sam Patterson,"6' 3""",170 lbs.,"78""",Orthodox,"Apr 30, 1996",http://ufcstats.com/fighter-details/8b6e5dc2ba1edbe7
+Zac Pauga,"6' 2""",205 lbs.,"76""",Orthodox,"Feb 25, 1988",http://ufcstats.com/fighter-details/56f7d7ee06be4aab
 Julio Paulino,"6' 0""",170 lbs.,--,Orthodox,"Dec 04, 1975",http://ufcstats.com/fighter-details/60c72f7459827881
+Thomas Paull,"5' 7""",155 lbs.,"67""",Orthodox,"Oct 15, 1994",http://ufcstats.com/fighter-details/dda67d7d3df6b406
 Sergei Pavlovich,"6' 3""",257 lbs.,"84""",Southpaw,"May 13, 1992",http://ufcstats.com/fighter-details/f14cf73e51b29254
 Pawel Pawlak,"6' 0""",170 lbs.,"73""",Orthodox,"Feb 08, 1989",http://ufcstats.com/fighter-details/9310418684bc896f
 Estevan Payan,"5' 10""",145 lbs.,--,Orthodox,"Mar 14, 1982",http://ufcstats.com/fighter-details/d0a5ef38a7778ac2
@@ -2562,12 +2927,15 @@ Andre Pederneiras,"5' 8""",155 lbs.,--,Orthodox,"Mar 22, 1967",http://ufcstats.c
 Carlo Pedersoli Jr.,"5' 11""",170 lbs.,"75""",Southpaw,"Jun 08, 1993",http://ufcstats.com/fighter-details/198994b47f395af0
 Matt Pedro,--,--,--,,--,http://ufcstats.com/fighter-details/f354c50b8d63d9b3
 Tyson Pedro,"6' 3""",205 lbs.,"79""",Orthodox,"Sep 17, 1991",http://ufcstats.com/fighter-details/49e96ff8ab781589
+Trevor Peek,"5' 9""",155 lbs.,"70""",Switch,"Jan 09, 1995",http://ufcstats.com/fighter-details/0bc697c5936a2d0a
 Willie Peeters,"5' 9""",220 lbs.,--,Orthodox,"Oct 26, 1965",http://ufcstats.com/fighter-details/e7bfdb5e0112891e
 Filip Pejic,"5' 8""",135 lbs.,--,Orthodox,"Jul 21, 1992",http://ufcstats.com/fighter-details/38ed5a2299230227
 Kurt Pellegrino,"5' 8""",155 lbs.,"70""",Orthodox,"May 07, 1979",http://ufcstats.com/fighter-details/aa1952ec0b3dd8e1
 Yan Pellerin,"5' 11""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/bfe95ec546692b13
 Julianna Pena,"5' 6""",135 lbs.,"69""",Orthodox,"Aug 19, 1989",http://ufcstats.com/fighter-details/3253b16d38ae087d
 Luis Pena,"6' 3""",155 lbs.,"75""",Southpaw,"Jul 05, 1993",http://ufcstats.com/fighter-details/2844b047183a1adb
+Felipe Pena,--,--,--,,"Oct 19, 1991",http://ufcstats.com/fighter-details/566ff9546fc29acd
+Matej Penaz,"6' 3""",185 lbs.,"83""",Southpaw,"Oct 14, 1996",http://ufcstats.com/fighter-details/abd64006fd37298d
 Sherman Pendergarst,"6' 1""",235 lbs.,--,Orthodox,"Aug 01, 1967",http://ufcstats.com/fighter-details/e670f8cc2969a789
 Drew Pendleton,--,145 lbs.,--,,"Dec 08, 1983",http://ufcstats.com/fighter-details/34b634cb2471bdde
 Cathal Pendred,"6' 1""",170 lbs.,"75""",Orthodox,"Sep 02, 1987",http://ufcstats.com/fighter-details/99c7610aa74995d3
@@ -2575,37 +2943,43 @@ BJ Penn,"5' 9""",155 lbs.,"70""",Orthodox,"Dec 13, 1978",http://ufcstats.com/fig
 Jessica Penne,"5' 5""",115 lbs.,"67""",Orthodox,"Jan 30, 1983",http://ufcstats.com/fighter-details/c742287ed86a09bc
 Nick Penner,"6' 4""",205 lbs.,--,Southpaw,"Mar 26, 1980",http://ufcstats.com/fighter-details/879b8df81523d91b
 Justin Pennington,"5' 4""",--,--,,--,http://ufcstats.com/fighter-details/0699c4b2a7c3c76f
-Raquel Pennington,"5' 7""",145 lbs.,"67""",Orthodox,"Sep 05, 1988",http://ufcstats.com/fighter-details/fc169c387b4b465d
+Raquel Pennington,"5' 7""",135 lbs.,"67""",Orthodox,"Sep 05, 1988",http://ufcstats.com/fighter-details/fc169c387b4b465d
+Tecia Pennington,"5' 1""",115 lbs.,"60""",Orthodox,"Aug 16, 1989",http://ufcstats.com/fighter-details/31ef8b67e13495b3
 Jerron Peoples,"6' 0""",170 lbs.,--,,"May 04, 1982",http://ufcstats.com/fighter-details/a2ac473d74eb157c
 Godofredo Pepey,"5' 7""",145 lbs.,"73""",Orthodox,"Jul 02, 1987",http://ufcstats.com/fighter-details/fa37628269132d1a
 Ray Perales,"5' 10""",170 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/9a70f67ad2187fa3
 Robert Peralta,"5' 8""",145 lbs.,"71""",Orthodox,"Mar 14, 1986",http://ufcstats.com/fighter-details/960d6cae8879ba2b
 Viviane Pereira,"5' 1""",115 lbs.,"63""",Orthodox,"Aug 28, 1993",http://ufcstats.com/fighter-details/d50382dc0565a9e1
-Michel Pereira,"6' 1""",170 lbs.,"73""",Orthodox,"Oct 06, 1993",http://ufcstats.com/fighter-details/595db60957de51d3
-Alex Pereira,"6' 4""",185 lbs.,"79""",Orthodox,"Jul 07, 1987",http://ufcstats.com/fighter-details/e5549c82bfb5582d
+Michel Pereira,"6' 1""",185 lbs.,"73""",Orthodox,"Oct 06, 1993",http://ufcstats.com/fighter-details/595db60957de51d3
+Alex Pereira,"6' 4""",205 lbs.,"79""",Orthodox,"Jul 07, 1987",http://ufcstats.com/fighter-details/e5549c82bfb5582d
 Daniel Pereira,"5' 10""",185 lbs.,--,,"Dec 13, 1990",http://ufcstats.com/fighter-details/44f46b0592ca0814
+Luciano Pereira,--,125 lbs.,--,Orthodox,"Jan 09, 2001",http://ufcstats.com/fighter-details/d7ee49bf3c779fa6
 Rolando Perez,"5' 8""",135 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/4a9e305633f3ef47
 Philip Perez,"5' 5""",155 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/eee8efec7b951d84
 Erik Perez,"5' 8""",135 lbs.,"68""",Orthodox,"Nov 19, 1989",http://ufcstats.com/fighter-details/af62f99eb7606308
-Alejandro Perez,"5' 6""",135 lbs.,"65""",Orthodox,"Sep 02, 1989",http://ufcstats.com/fighter-details/80daefbed11ce998
+Alejandro Perez,"5' 6""",135 lbs.,"67""",Orthodox,"Sep 02, 1989",http://ufcstats.com/fighter-details/80daefbed11ce998
 Frankie Perez,"5' 11""",155 lbs.,"73""",Orthodox,"May 11, 1989",http://ufcstats.com/fighter-details/96c336b463e0662c
 Jose Perez,--,--,--,,--,http://ufcstats.com/fighter-details/89578ae236ee04e9
 Alex Perez,"5' 6""",125 lbs.,"65""",Orthodox,"Mar 21, 1992",http://ufcstats.com/fighter-details/ab2b4ff41d6ebe0f
 Markus Perez,"6' 1""",185 lbs.,"73""",Orthodox,"Jun 22, 1988",http://ufcstats.com/fighter-details/2ac4628c08ec5125
+Ailin Perez,"5' 5""",135 lbs.,"66""",Switch,"Oct 05, 1994",http://ufcstats.com/fighter-details/06e4245d16fc5315
 Anthony Perosh,"6' 3""",205 lbs.,"75""",Orthodox,"Oct 05, 1972",http://ufcstats.com/fighter-details/4b4753d19489297f
 Thiago Perpetuo,"5' 10""",170 lbs.,--,Orthodox,"Dec 14, 1987",http://ufcstats.com/fighter-details/c1a5d3843596df92
 Hernani Perpetuo,"6' 0""",170 lbs.,--,Orthodox,"May 24, 1985",http://ufcstats.com/fighter-details/575360be653ad6a6
-Jay Perrin,"5' 7""",135 lbs.,"69""",Switch,"Jun 15, 1993",http://ufcstats.com/fighter-details/01fed6f61ebea01f
+Jay Perrin,"5' 7""",135 lbs.,"67""",Switch,"Jun 15, 1993",http://ufcstats.com/fighter-details/01fed6f61ebea01f
 Mike Perry,"5' 10""",170 lbs.,"71""",Orthodox,"Sep 15, 1991",http://ufcstats.com/fighter-details/f2b6fdb20675b11c
 Raphael Pessoa,"6' 3""",262 lbs.,"78""",Orthodox,"Mar 09, 1989",http://ufcstats.com/fighter-details/41f90012b86a11bf
 Viktor Pesta,"6' 3""",240 lbs.,"77""",Orthodox,"Jul 15, 1990",http://ufcstats.com/fighter-details/202b0467521c9d6f
 Leiticia Pestova,"5' 6""",135 lbs.,--,Orthodox,"Jan 15, 1984",http://ufcstats.com/fighter-details/f3743d8ef5dde970
 Tony Petarra,"5' 11""",196 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/c61f66d8c3fd5f07
 Tommy Petersen,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/7aabd61419f747d1
+Thomas Petersen,"6' 1""",264 lbs.,"74""",Southpaw,"Mar 30, 1995",http://ufcstats.com/fighter-details/764d39074a352e33
 Cory Peterson,"6' 11""",400 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/5df10509264586e5
 Steven Peterson,"5' 10""",145 lbs.,"70""",Orthodox,"May 29, 1990",http://ufcstats.com/fighter-details/b93c06d09d1c4ac0
+Vitor Petrino,"6' 2""",205 lbs.,"77""",Orthodox,"Aug 28, 1997",http://ufcstats.com/fighter-details/71171fc96445bf65
 Andre Petroski,"6' 0""",185 lbs.,"73""",Switch,"Jun 12, 1991",http://ufcstats.com/fighter-details/5f61780fe5e9b6d0
-Armen Petrosyan,"6' 3""",185 lbs.,"71""",Orthodox,"Nov 02, 1990",http://ufcstats.com/fighter-details/369ea36e450ae62a
+Armen Petrosyan,"6' 3""",185 lbs.,"71""",Orthodox,"Nov 03, 1990",http://ufcstats.com/fighter-details/369ea36e450ae62a
+Ivana Petrovic,"5' 8""",125 lbs.,"70""",Southpaw,"Jun 11, 1994",http://ufcstats.com/fighter-details/38c5817ade8a8014
 Seth Petruzelli,"6' 0""",205 lbs.,"76""",Orthodox,"Dec 03, 1979",http://ufcstats.com/fighter-details/93b9496275bbbf80
 Peter Petties,"5' 11""",145 lbs.,"72""",Southpaw,"Dec 20, 1990",http://ufcstats.com/fighter-details/7ea5d60d2e6a8ad0
 Anthony Pettis,"5' 10""",155 lbs.,"72""",Orthodox,"Jan 27, 1987",http://ufcstats.com/fighter-details/cbb682f5fcc44bfc
@@ -2621,15 +2995,19 @@ Aaron Phillips,"5' 9""",135 lbs.,"71""",Southpaw,"Aug 05, 1989",http://ufcstats.
 Elizabeth Phillips,"5' 6""",135 lbs.,"65""",Orthodox,"Aug 20, 1986",http://ufcstats.com/fighter-details/dcbf01d605681ad1
 John Phillips,"5' 11""",185 lbs.,"75""",Southpaw,"Jun 09, 1985",http://ufcstats.com/fighter-details/e9ac7bfb65c25497
 Kyler Phillips,"5' 8""",135 lbs.,"72""",Orthodox,"Jun 12, 1995",http://ufcstats.com/fighter-details/60425d07ef4b91a7
+Mario Piazzon,"5' 9""",265 lbs.,"73""",Orthodox,"Apr 06, 1998",http://ufcstats.com/fighter-details/44f234a36324e6c8
 Nick Pica,"5' 10""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/7922e8269adcc25a
+Nick Piccininni,"5' 6""",125 lbs.,"66""",Orthodox,"Dec 16, 1996",http://ufcstats.com/fighter-details/a5cb1c29461853ca
 Adam Piccolotti,"5' 11""",155 lbs.,--,,"Oct 23, 1988",http://ufcstats.com/fighter-details/fa399f7f6e17f7f5
 Vinc Pichel,"5' 10""",155 lbs.,"72""",Orthodox,"Nov 23, 1982",http://ufcstats.com/fighter-details/c77a953488e5607d
 Brad Pickett,"5' 6""",135 lbs.,"68""",Orthodox,"Sep 24, 1978",http://ufcstats.com/fighter-details/c945adc22c2bfe8f
 Jamie Pickett,"6' 2""",185 lbs.,"80""",Orthodox,"Aug 29, 1988",http://ufcstats.com/fighter-details/830f60497fab345a
+Fabiola Pidroni,--,115 lbs.,--,,"Jan 04, 1994",http://ufcstats.com/fighter-details/9561eb5f0d63ffcc
 Oskar Piechota,"6' 0""",185 lbs.,"76""",Southpaw,"Jan 24, 1990",http://ufcstats.com/fighter-details/1cf7ccf64a5bf24e
 Nick Piedmont,"5' 10""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/df7d386a54e07446
 Mike Pierce,"5' 8""",170 lbs.,"71""",Orthodox,"Sep 01, 1980",http://ufcstats.com/fighter-details/236a37d96d476164
 Joao Pierini,"6' 1""",155 lbs.,--,Switch,"Dec 11, 1971",http://ufcstats.com/fighter-details/9a967e8e43dcef63
+Jonathan Piersma,"5' 11""",170 lbs.,"73""",Orthodox,"Mar 03, 1996",http://ufcstats.com/fighter-details/1c7308d2957a12d2
 Sean Pierson,"6' 0""",170 lbs.,"76""",Southpaw,"Mar 10, 1976",http://ufcstats.com/fighter-details/0d506315895efffc
 Domingo Pilarte,"6' 0""",135 lbs.,"73""",Southpaw,"Jan 05, 1990",http://ufcstats.com/fighter-details/4bf6b225ff6099c4
 Paddy Pimblett,"5' 10""",155 lbs.,"73""",Orthodox,"Jan 03, 1995",http://ufcstats.com/fighter-details/7826923b47f8d72a
@@ -2637,6 +3015,7 @@ Daniel Pineda,"5' 7""",145 lbs.,"69""",Orthodox,"Aug 06, 1985",http://ufcstats.c
 Jesus Pinedo,"5' 10""",155 lbs.,--,Southpaw,"Jun 22, 1996",http://ufcstats.com/fighter-details/25af5e832f17b474
 Pingyuan Liu,"5' 6""",135 lbs.,"72""",Orthodox,"Feb 13, 1993",http://ufcstats.com/fighter-details/31bbd39c0a075d4e
 Luana Pinheiro,"5' 2""",115 lbs.,"62""",Orthodox,"Nov 18, 1992",http://ufcstats.com/fighter-details/a3a542074109b347
+Mario Pinto,"6' 5""",265 lbs.,"79""",Orthodox,"Mar 14, 1998",http://ufcstats.com/fighter-details/39d309957c5c210d
 Gaetano Pirrello,"5' 7""",135 lbs.,"65""",Orthodox,"Apr 29, 1992",http://ufcstats.com/fighter-details/8765559b6a29a421
 Maki Pitolo,"5' 10""",185 lbs.,"75""",Orthodox,"Nov 24, 1990",http://ufcstats.com/fighter-details/c549573c0df4d676
 Dmitry Poberezhets,"6' 3""",237 lbs.,--,,"Jun 11, 1985",http://ufcstats.com/fighter-details/9756095cb76b67c3
@@ -2645,7 +3024,7 @@ Ross Pointon,"5' 8""",170 lbs.,--,Orthodox,"Feb 18, 1980",http://ufcstats.com/fi
 Dustin Poirier,"5' 9""",155 lbs.,"72""",Southpaw,"Jan 19, 1989",http://ufcstats.com/fighter-details/029eaff01e6bb8f0
 Igor Pokrajac,"6' 0""",205 lbs.,"74""",Orthodox,"Jan 02, 1979",http://ufcstats.com/fighter-details/53278852bcd91e11
 John Polakowski,"5' 10""",155 lbs.,--,Orthodox,"Jun 21, 1981",http://ufcstats.com/fighter-details/b18fb36a4aa00093
-Julia Polastri,"5' 2""",125 lbs.,"63""",Orthodox,"Mar 05, 1998",http://ufcstats.com/fighter-details/abb68e3c7ca128f2
+Julia Polastri,"5' 2""",115 lbs.,"63""",Orthodox,"Mar 05, 1998",http://ufcstats.com/fighter-details/abb68e3c7ca128f2
 Brandon Polcare,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/543cd2258f4fa339
 Mike Polchlopek,"6' 4""",285 lbs.,--,Orthodox,"Dec 27, 1965",http://ufcstats.com/fighter-details/3bb030257966b022
 Santiago Ponzinibbio,"6' 0""",170 lbs.,"73""",Orthodox,"Sep 26, 1986",http://ufcstats.com/fighter-details/6d1bffff14897645
@@ -2653,16 +3032,18 @@ Grigory Popov,"5' 7""",135 lbs.,"68""",Switch,"Apr 18, 1984",http://ufcstats.com
 Alexander Poppeck,"6' 2""",205 lbs.,--,Orthodox,"Apr 06, 1992",http://ufcstats.com/fighter-details/56bf3ed155bd0fcd
 Felipe Portela,--,170 lbs.,--,,"Nov 23, 1987",http://ufcstats.com/fighter-details/303e017a9074f3aa
 Parker Porter,"6' 0""",265 lbs.,"75""",Orthodox,"Apr 22, 1985",http://ufcstats.com/fighter-details/ac40f7e3cbecdda4
-Ihor Potieria,"6' 3""",205 lbs.,"75""",Southpaw,"May 29, 1996",http://ufcstats.com/fighter-details/260bd4cef10b033f
+Ihor Potieria,"6' 3""",185 lbs.,"75""",Southpaw,"May 29, 1996",http://ufcstats.com/fighter-details/260bd4cef10b033f
 Callan Potter,"6' 0""",170 lbs.,"72""",Orthodox,"Jun 09, 1984",http://ufcstats.com/fighter-details/8fc9ae9c7527dfcb
 Dylan Potter,"6' 2""",225 lbs.,"77""",Switch,"Jan 14, 1995",http://ufcstats.com/fighter-details/61e47575b24a06bf
 Ruan Potts,"6' 2""",247 lbs.,"75""",Orthodox,"Feb 23, 1978",http://ufcstats.com/fighter-details/7e208569469c8bc8
 Devin Powell,"6' 0""",155 lbs.,"73""",Orthodox,"Mar 01, 1988",http://ufcstats.com/fighter-details/065eb44700e641a4
 Marcin Prachnio,"6' 3""",205 lbs.,"74""",Orthodox,"Jul 14, 1988",http://ufcstats.com/fighter-details/6370c1c1e12723d5
 Wagner Prado,"6' 0""",205 lbs.,"74""",Southpaw,"Dec 30, 1986",http://ufcstats.com/fighter-details/7f6ef4e1227600bc
+Francisco Prado,"5' 10""",155 lbs.,"69""",Orthodox,"Jun 16, 2002",http://ufcstats.com/fighter-details/3920d0cc288f9b0d
 Trevor Prangley,"6' 1""",185 lbs.,"75""",Orthodox,"Aug 24, 1972",http://ufcstats.com/fighter-details/f5ff7bcdcfeba3ad
 Ricardo Prasel,"6' 7""",238 lbs.,"78""",Orthodox,"Jun 02, 1990",http://ufcstats.com/fighter-details/b51d0ed3782a1bf5
 Carlo Prater,"5' 11""",155 lbs.,"72""",Switch,"Jun 25, 1981",http://ufcstats.com/fighter-details/4f853e98886283cf
+Carlos Prates,"6' 1""",170 lbs.,"78""",Switch,"Aug 17, 1993",http://ufcstats.com/fighter-details/7ee0fd831c0fe7c3
 Michel Prazeres,"5' 6""",170 lbs.,"67""",Orthodox,"Jul 25, 1981",http://ufcstats.com/fighter-details/e51fcd9cd84c0b93
 Philip Preece,"5' 8""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/6597b611f1c32555
 Kyle Prepolec,"5' 10""",170 lbs.,"70""",Southpaw,"Aug 30, 1989",http://ufcstats.com/fighter-details/873626e5547b5235
@@ -2684,41 +3065,49 @@ Juan Manuel Puig,"5' 9""",145 lbs.,--,Orthodox,"Apr 23, 1989",http://ufcstats.co
 Hugh Pulley,"6' 0""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/308279bd246c211f
 Josh Pulsifer,"5' 10""",145 lbs.,--,,"Mar 16, 1983",http://ufcstats.com/fighter-details/16867810070dc520
 Jens Pulver,"5' 7""",145 lbs.,"70""",Southpaw,"Dec 06, 1974",http://ufcstats.com/fighter-details/44260175069b6276
+Andrey Pulyaev,"6' 4""",185 lbs.,"78""",Southpaw,"Sep 10, 1997",http://ufcstats.com/fighter-details/22e07d3da1aa3475
 CM Punk,"6' 1""",170 lbs.,"73""",Orthodox,"Oct 26, 1978",http://ufcstats.com/fighter-details/a8c9d16fe2a14d72
 Joe Pyfer,"6' 2""",185 lbs.,"75""",Orthodox,"Sep 17, 1996",http://ufcstats.com/fighter-details/c1085e1701b13eca
 Mike Pyle,"6' 0""",170 lbs.,"74""",Orthodox,"Sep 18, 1975",http://ufcstats.com/fighter-details/f5990c11974d8e9c
+Pat Pytlik,"6' 0""",170 lbs.,"73""",Orthodox,"Apr 24, 1989",http://ufcstats.com/fighter-details/4fd140eea593526e
 Qiu Lun,"5' 8""",125 lbs.,"66""",Southpaw,"Jul 08, 1997",http://ufcstats.com/fighter-details/126bdc1710a8cbf4
 Bao Quach,"5' 3""",145 lbs.,--,Orthodox,"Sep 04, 1979",http://ufcstats.com/fighter-details/d365ee924f5cc3fc
 Gary Quan,"5' 8""",143 lbs.,--,,"Apr 11, 1971",http://ufcstats.com/fighter-details/f7b4cbe93f3bac06
 Billy Quarantillo,"5' 10""",145 lbs.,"70""",Orthodox,"Dec 08, 1988",http://ufcstats.com/fighter-details/aa171d55d4b5208f
 Nate Quarry,"6' 0""",185 lbs.,"72""",Open Stance,"Mar 18, 1972",http://ufcstats.com/fighter-details/52cae54377b433b7
-Vinicius Queiroz,"6' 7""",220 lbs.,--,,"Aug 29, 1983",http://ufcstats.com/fighter-details/2a8502954f49e682
+Vinicius Queiroz,"6' 7""",220 lbs.,--,Orthodox,"Aug 29, 1983",http://ufcstats.com/fighter-details/2a8502954f49e682
 Jimmy Quinlan,"6' 0""",185 lbs.,--,Orthodox,"May 25, 1986",http://ufcstats.com/fighter-details/ddbe4fa2ea573393
 Josh Quinlan,"6' 0""",170 lbs.,"72""",Orthodox,"Feb 06, 1993",http://ufcstats.com/fighter-details/876f478f796495f7
 Ryan Quinn,"5' 8""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/cc23ed51619421a3
 Michel Quinones,"5' 10""",155 lbs.,"73""",Orthodox,"Dec 22, 1984",http://ufcstats.com/fighter-details/5e84a859c6a82288
-Landon Quinones,"5' 9""",155 lbs.,--,Southpaw,"Nov 21, 1995",http://ufcstats.com/fighter-details/267f4a6568abe245
+Landon Quinones,"5' 9""",155 lbs.,"70""",Southpaw,"Nov 21, 1995",http://ufcstats.com/fighter-details/267f4a6568abe245
 Jose Quinonez,"5' 8""",135 lbs.,"69""",Southpaw,"Jul 28, 1990",http://ufcstats.com/fighter-details/36549928f90f1d36
-Christian Quinonez,"5' 7""",135 lbs.,"70""",Orthodox,"Apr 26, 1996",http://ufcstats.com/fighter-details/7debc13b36343605
+Cristian Quinonez,"5' 8""",135 lbs.,"70""",Orthodox,"Apr 26, 1996",http://ufcstats.com/fighter-details/7debc13b36343605
 Benji Radach,"5' 10""",185 lbs.,--,Orthodox,"Apr 05, 1979",http://ufcstats.com/fighter-details/01b39decaf0abf6a
 Jordan Radev,"5' 7""",185 lbs.,--,Southpaw,"Sep 28, 1976",http://ufcstats.com/fighter-details/45bc8f98d62bd096
+Charles Radtke,"5' 9""",170 lbs.,"72""",Orthodox,"Jul 09, 1990",http://ufcstats.com/fighter-details/feedf3053472fe56
+Loik Radzhabov,"5' 11""",155 lbs.,"69""",Orthodox,"Sep 17, 1990",http://ufcstats.com/fighter-details/8c169fbe1ac33637
 Gilbert Rael,"5' 8""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/6cc25d19a891f435
 Josh Rafferty,"6' 0""",170 lbs.,--,Orthodox,"Jan 06, 1981",http://ufcstats.com/fighter-details/ff2c606c8bc365e3
 Amir Rahnavardi,"6' 0""",205 lbs.,--,Orthodox,"Dec 07, 1974",http://ufcstats.com/fighter-details/bc7f7f0ba3db74d2
 Ricky Rainey,"6' 1""",170 lbs.,"77""",Switch,"Jun 29, 1983",http://ufcstats.com/fighter-details/9b1e3fb4f8cbd5b7
 Shavkat Rakhmonov,"6' 1""",170 lbs.,"77""",Orthodox,"Oct 23, 1994",http://ufcstats.com/fighter-details/01afe0916a40c7c5
+Sora Rakhmonova,--,125 lbs.,--,,"Jun 21, 1998",http://ufcstats.com/fighter-details/63ff619c52ff7976
 Aleksandar Rakic,"6' 4""",205 lbs.,"78""",Orthodox,"Feb 06, 1992",http://ufcstats.com/fighter-details/333b9e5c723ac873
 Jessica Rakoczy,"5' 7""",115 lbs.,--,Orthodox,"Apr 14, 1977",http://ufcstats.com/fighter-details/ffdeb4fbea09ce75
+Zygimantas Ramaska,"5' 11""",145 lbs.,"71""",Orthodox,"Dec 27, 1996",http://ufcstats.com/fighter-details/641ca2c2ed91b93c
 Thomas Ramirez,"6' 1""",410 lbs.,--,Sideways,--,http://ufcstats.com/fighter-details/ea398c802d9998ee
 Hector Ramirez,"6' 0""",205 lbs.,--,Orthodox,"Mar 28, 1976",http://ufcstats.com/fighter-details/d1759b2b7be9be56
 Matt Ramirez,"5' 5""",125 lbs.,--,,--,http://ufcstats.com/fighter-details/96c05ba5ab9eccaf
 Steve Ramirez,"5' 7""",125 lbs.,--,,--,http://ufcstats.com/fighter-details/4311e9d23604205c
 Amador Ramirez,--,135 lbs.,--,,"Jun 14, 1990",http://ufcstats.com/fighter-details/ac31f869959860bc
+Mitch Ramirez,"5' 11""",155 lbs.,"71""",Orthodox,"Nov 03, 1992",http://ufcstats.com/fighter-details/e99eb0ef25885de5
 Andrew Ramm,"6' 1""",160 lbs.,--,,--,http://ufcstats.com/fighter-details/3b5f2faaa2f2c1f6
 Ian Rammel,"6' 0""",185 lbs.,--,,"Jul 22, 1985",http://ufcstats.com/fighter-details/abc8e1423cf5b74e
 Luis Ramos,"5' 8""",170 lbs.,--,Orthodox,"Jan 18, 1981",http://ufcstats.com/fighter-details/7bc475b0fc2020ab
 Ricardo Ramos,"5' 9""",145 lbs.,"72""",Orthodox,"Aug 01, 1995",http://ufcstats.com/fighter-details/1ae8f3c723aacff4
 Davi Ramos,"5' 6""",155 lbs.,"70""",Orthodox,"Nov 05, 1986",http://ufcstats.com/fighter-details/0052de90691d4a93
+Dorian Ramos,"5' 8""",145 lbs.,"70""",Orthodox,"Dec 31, 1993",http://ufcstats.com/fighter-details/fa4dcb2c8de482ee
 Vernon Ramos Ho,"5' 6""",170 lbs.,--,Orthodox,"Jun 03, 1992",http://ufcstats.com/fighter-details/30b577b112bef42d
 Kevin Randleman,"5' 10""",205 lbs.,--,Orthodox,"Aug 10, 1971",http://ufcstats.com/fighter-details/6859f67468ba8489
 Raou Raou,"5' 8""",195 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/ed069a95aaaf4f56
@@ -2734,6 +3123,7 @@ Keenan Raymond,--,165 lbs.,--,,--,http://ufcstats.com/fighter-details/bdd16cd6b2
 Iony Razafiarison,"5' 3""",145 lbs.,--,,"Dec 23, 1984",http://ufcstats.com/fighter-details/a303588c33d8c5ae
 Abdul Razak Alhassan,"5' 10""",185 lbs.,"73""",Orthodox,"Aug 11, 1985",http://ufcstats.com/fighter-details/eae431e70064e046
 Antony Rea,"6' 0""",205 lbs.,--,Orthodox,"Jul 15, 1976",http://ufcstats.com/fighter-details/c36e1f4fa755ffb4
+Mateusz Rebecki,"5' 7""",155 lbs.,"66""",Southpaw,"Nov 03, 1992",http://ufcstats.com/fighter-details/849c5d9979df5357
 Rafael Rebello,"5' 5""",135 lbs.,"67""",Orthodox,"Oct 16, 1980",http://ufcstats.com/fighter-details/972197a8c61ac413
 Greg Rebello,"6' 0""",240 lbs.,"73""",Southpaw,"Jun 13, 1982",http://ufcstats.com/fighter-details/49d78120e0a4f607
 Paul Redmond,"5' 10""",145 lbs.,--,Orthodox,"Oct 20, 1986",http://ufcstats.com/fighter-details/3f56b99447f00607
@@ -2743,6 +3133,7 @@ Elise Reed,"5' 3""",115 lbs.,"63""",Orthodox,"Dec 05, 1992",http://ufcstats.com/
 John Reedy,"5' 8""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/fb4ca5c7e4448645
 Johnny Rees,"6' 0""",170 lbs.,--,Orthodox,"Oct 21, 1982",http://ufcstats.com/fighter-details/3ba3b5cc94498437
 James Reese,"5' 9""",155 lbs.,--,,"Dec 21, 1980",http://ufcstats.com/fighter-details/e9ec08ebb3f92aa3
+Zachary Reese,"6' 4""",185 lbs.,"77""",Switch,"Mar 24, 1994",http://ufcstats.com/fighter-details/23dec7c47cb418f8
 Stephen Regman,"5' 11""",185 lbs.,"76""",Orthodox,"Aug 05, 1991",http://ufcstats.com/fighter-details/24d98df7556ac8af
 Chad Reiner,"5' 11""",170 lbs.,--,Orthodox,"Jun 29, 1981",http://ufcstats.com/fighter-details/d8022d5526b1d937
 Jason Reinhardt,"5' 6""",135 lbs.,--,Orthodox,"Oct 31, 1969",http://ufcstats.com/fighter-details/02500fb9fd79a974
@@ -2750,23 +3141,28 @@ Wilson Reis,"5' 4""",125 lbs.,"65""",Southpaw,"Jan 06, 1985",http://ufcstats.com
 Ben Reiter,"6' 3""",185 lbs.,--,,"Jun 27, 1987",http://ufcstats.com/fighter-details/ee7b7768a4e6dc45
 Goran Reljic,"6' 3""",205 lbs.,"81""",Southpaw,"Mar 20, 1984",http://ufcstats.com/fighter-details/132f860d02953f4c
 Leigh Remedios,"5' 7""",155 lbs.,--,Orthodox,"Jan 13, 1976",http://ufcstats.com/fighter-details/918db42c3637916f
+Paulo Renato Junior,"6' 0""",205 lbs.,"73""",Orthodox,"Jan 25, 1994",http://ufcstats.com/fighter-details/01dfb60661153735
 Chance Rencountre,"6' 2""",170 lbs.,"75""",Southpaw,"Dec 31, 1986",http://ufcstats.com/fighter-details/1ddb480b601cefb1
+Montserrat Rendon,"5' 8""",135 lbs.,"68""",Orthodox,"Mar 16, 1989",http://ufcstats.com/fighter-details/60193e707634e560
 Marion Reneau,"5' 6""",135 lbs.,"68""",Orthodox,"Jun 20, 1977",http://ufcstats.com/fighter-details/c7d297714d9ab1a4
 Solomon Renfro,"5' 9""",170 lbs.,"72""",Switch,"Feb 05, 1997",http://ufcstats.com/fighter-details/ce6b5b93a96dd15b
 John Renken,"6' 0""",190 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/1507214bbc7a79e2
 Herman Renting,"6' 0""",215 lbs.,--,Switch,--,http://ufcstats.com/fighter-details/f57cf3d54a641385
 Marco Polo Reyes,"5' 11""",155 lbs.,"71""",Orthodox,"Nov 07, 1984",http://ufcstats.com/fighter-details/edd02825c29028fe
 Dominick Reyes,"6' 4""",205 lbs.,"77""",Southpaw,"Dec 26, 1989",http://ufcstats.com/fighter-details/2e19380f34871c6a
-Alex Reyes,"5' 11""",170 lbs.,"73""",Orthodox,"Oct 02, 1986",http://ufcstats.com/fighter-details/dc07493a87dc0a6e
+Alex Reyes,"5' 11""",155 lbs.,"73""",Orthodox,"Oct 02, 1986",http://ufcstats.com/fighter-details/dc07493a87dc0a6e
 Kyle Reyes,"5' 8""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/7333d6e0f6428acb
 Victor Reyna,"5' 11""",170 lbs.,"74""",Southpaw,"Aug 05, 1986",http://ufcstats.com/fighter-details/e9bbcc6530e4cbe6
 Gaston Reyno,"6' 0""",145 lbs.,--,,"Nov 11, 1986",http://ufcstats.com/fighter-details/64db35f7782fe274
 Johnny Rhodes,"6' 0""",210 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/319fa1bd3176bded
 Mike Rhodes,"6' 1""",170 lbs.,"74""",Orthodox,"Dec 04, 1989",http://ufcstats.com/fighter-details/b7ad576b8ae115e6
 Lucrezia Ria,"5' 6""",125 lbs.,--,Orthodox,"Jun 24, 1992",http://ufcstats.com/fighter-details/042cc07ad5a53a33
-Amanda Ribas,"5' 3""",125 lbs.,"66""",Orthodox,"Aug 26, 1993",http://ufcstats.com/fighter-details/beecb672a279223e
+Amanda Ribas,"5' 3""",115 lbs.,"66""",Orthodox,"Aug 26, 1993",http://ufcstats.com/fighter-details/beecb672a279223e
 Vitor Ribeiro,"5' 8""",154 lbs.,--,Orthodox,"Feb 24, 1979",http://ufcstats.com/fighter-details/a757c06bbdba61d2
 Will Ribeiro,"5' 8""",135 lbs.,--,Orthodox,"Feb 17, 1983",http://ufcstats.com/fighter-details/8f4616698508f24d
+Claudio Ribeiro,"6' 1""",185 lbs.,"77""",Orthodox,"Jul 17, 1992",http://ufcstats.com/fighter-details/972c456ff38b2015
+Brendson Ribeiro,"6' 3""",205 lbs.,"81""",Orthodox,"Sep 08, 1996",http://ufcstats.com/fighter-details/49edd0d90f60fb7d
+Esteban Ribovics,"5' 10""",155 lbs.,"69""",Orthodox,"Apr 27, 1996",http://ufcstats.com/fighter-details/323d4ca260dfa0ba
 Mike Ricci,"6' 0""",155 lbs.,"76""",Southpaw,"Mar 18, 1986",http://ufcstats.com/fighter-details/3c921b1a30fdcbdd
 Alex Ricci,"5' 11""",155 lbs.,--,Orthodox,"Jul 21, 1982",http://ufcstats.com/fighter-details/bf9bc96336922271
 Tabatha Ricci,"5' 1""",115 lbs.,"61""",Orthodox,"Feb 21, 1995",http://ufcstats.com/fighter-details/d25240135aee03e5
@@ -2775,15 +3171,18 @@ John Richard,--,205 lbs.,--,,"May 22, 1982",http://ufcstats.com/fighter-details/
 Rex Richards,"6' 5""",265 lbs.,--,,--,http://ufcstats.com/fighter-details/ad23903ef3af7406
 Mike Richman,"5' 8""",135 lbs.,--,,"Jun 23, 1985",http://ufcstats.com/fighter-details/d6a740cf6e898e27
 Dave Rickels,"5' 11""",155 lbs.,--,,"Jan 05, 1989",http://ufcstats.com/fighter-details/98b76850b5f1e836
+Haisam Rida,--,--,--,,"Jul 25, 1993",http://ufcstats.com/fighter-details/d8a58e797518f011
 Brad Riddell,"5' 7""",155 lbs.,"71""",Orthodox,"Sep 30, 1991",http://ufcstats.com/fighter-details/37ed1ab2f8b819f4
 Matthew Riddle,"6' 1""",170 lbs.,"76""",Southpaw,"Jan 14, 1986",http://ufcstats.com/fighter-details/d023ae89a2a4a41e
 Joe Riggs,"6' 0""",185 lbs.,"70""",Southpaw,"Sep 23, 1982",http://ufcstats.com/fighter-details/d512d9f204059f57
 Jeremiah Riggs,"6' 0""",185 lbs.,--,,"Dec 17, 1982",http://ufcstats.com/fighter-details/f1a9ad7485e5024a
 Aaron Riley,"5' 8""",155 lbs.,"69""",Southpaw,"Dec 09, 1980",http://ufcstats.com/fighter-details/f2c8ebbeafd45f2b
 Jason Riley,"6' 6""",245 lbs.,--,,"Sep 22, 1975",http://ufcstats.com/fighter-details/995af04c697d78b7
+Luke Riley,--,145 lbs.,--,,"Jun 30, 1999",http://ufcstats.com/fighter-details/b1de86d835638319
 Moise Rimbon,"5' 10""",205 lbs.,--,Orthodox,"Apr 20, 1977",http://ufcstats.com/fighter-details/9be3728f3f7badb2
 Jordan Rinaldi,"5' 10""",145 lbs.,"72""",Orthodox,"Sep 25, 1987",http://ufcstats.com/fighter-details/c07efc18b231f170
 Nick Ring,"6' 0""",185 lbs.,"74""",Southpaw,"Feb 10, 1979",http://ufcstats.com/fighter-details/b13da0b1a3aed3e7
+Robbie Ring,"5' 9""",145 lbs.,"68""",Orthodox,"Jul 14, 2000",http://ufcstats.com/fighter-details/fa9746fa5d23c202
 Mike Rio,"5' 10""",155 lbs.,"70""",Orthodox,"Jul 06, 1981",http://ufcstats.com/fighter-details/af90b10c785ced3e
 Albert Rios,"5' 8""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/868a78f2e810a837
 Rafael Rios,--,150 lbs.,--,,--,http://ufcstats.com/fighter-details/2f5754b48eab1486
@@ -2803,7 +3202,7 @@ Pedro Rizzo,"6' 1""",241 lbs.,--,Orthodox,"May 03, 1974",http://ufcstats.com/fig
 Theo Rlayang,"5' 7""",145 lbs.,"65""",Orthodox,"Aug 10, 1994",http://ufcstats.com/fighter-details/8aabef76351401d0
 Justin Robbins,"5' 5""",135 lbs.,--,,"Jul 29, 1980",http://ufcstats.com/fighter-details/3b2485c8d5c8b580
 Kali Robbins,"5' 3""",115 lbs.,"63""",Orthodox,"Jul 05, 1984",http://ufcstats.com/fighter-details/610caee730f9b89e
-Karl Roberson,"6' 1""",185 lbs.,"74""",Southpaw,"Oct 04, 1990",http://ufcstats.com/fighter-details/37d5b176d438d2a5
+Karl Roberson,"6' 1""",205 lbs.,"74""",Southpaw,"Oct 04, 1990",http://ufcstats.com/fighter-details/37d5b176d438d2a5
 Andre Roberts,"6' 2""",345 lbs.,--,Orthodox,"Feb 24, 1965",http://ufcstats.com/fighter-details/a54a35a670d8e852
 David Roberts,"6' 1""",170 lbs.,--,Orthodox,"Nov 15, 1975",http://ufcstats.com/fighter-details/775bad6d700d2302
 Joey Roberts,"6' 2""",200 lbs.,--,,--,http://ufcstats.com/fighter-details/c058823a2595ab09
@@ -2815,7 +3214,7 @@ Buddy Roberts,"6' 2""",185 lbs.,--,Orthodox,"Oct 17, 1982",http://ufcstats.com/f
 Danny Roberts,"6' 1""",170 lbs.,"74""",Southpaw,"Jul 14, 1987",http://ufcstats.com/fighter-details/a6cba6bb66c1a8c9
 Roosevelt Roberts,"6' 2""",155 lbs.,"73""",Orthodox,"Feb 11, 1994",http://ufcstats.com/fighter-details/37c5366d18ed6c05
 Kenny Robertson,"5' 10""",170 lbs.,"74""",Orthodox,"Feb 14, 1984",http://ufcstats.com/fighter-details/6e0273f9478be71e
-Gillian Robertson,"5' 5""",125 lbs.,"63""",Orthodox,"May 17, 1995",http://ufcstats.com/fighter-details/38c7f72747f4f712
+Gillian Robertson,"5' 5""",115 lbs.,"63""",Orthodox,"May 17, 1995",http://ufcstats.com/fighter-details/38c7f72747f4f712
 Chad Robichaux,"5' 4""",135 lbs.,--,,"Aug 18, 1975",http://ufcstats.com/fighter-details/b2aa1e07b5b3306e
 Mark Robinson,"6' 0""",265 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/4604ab1de9058474
 Colin Robinson,"6' 4""",243 lbs.,--,Orthodox,"Nov 27, 1968",http://ufcstats.com/fighter-details/1a1a4d7a29041d77
@@ -2823,11 +3222,13 @@ Alvin Robinson,"5' 9""",155 lbs.,"68""",Southpaw,"Jul 16, 1982",http://ufcstats.
 Damonte Robinson,"6' 0""",155 lbs.,"77""",,"Jun 10, 1995",http://ufcstats.com/fighter-details/2782235b078b72a7
 Vagner Rocha,"5' 10""",155 lbs.,"73""",Orthodox,"Jun 06, 1982",http://ufcstats.com/fighter-details/d403b1a6f278c95e
 Carlos Eduardo Rocha,"5' 10""",170 lbs.,"73""",Orthodox,"Jul 12, 1981",http://ufcstats.com/fighter-details/4f736494fc733095
+Pedro Rocha,--,--,--,,--,http://ufcstats.com/fighter-details/5921fd3f889afa3b
+Lucas Rocha,"5' 3""",125 lbs.,"64""",Orthodox,"Aug 12, 2000",http://ufcstats.com/fighter-details/e0d3d9b564f95635
 Keith Rockel,"6' 0""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/c75b99887c8c3f5a
-Luke Rockhold,"6' 3""",205 lbs.,"77""",Southpaw,"Oct 17, 1984",http://ufcstats.com/fighter-details/00e11b5c8b7bfeeb
+Luke Rockhold,"6' 3""",185 lbs.,"77""",Southpaw,"Oct 17, 1984",http://ufcstats.com/fighter-details/00e11b5c8b7bfeeb
 Kevin Roddy,"5' 11""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/1abf785143f8d5ec
 Gregory Rodrigues,"6' 3""",185 lbs.,"75""",Orthodox,"Feb 17, 1992",http://ufcstats.com/fighter-details/d1c65d2cf2925ddd
-Kleydson Rodrigues,"5' 6""",125 lbs.,"67""",Orthodox,"Oct 22, 1995",http://ufcstats.com/fighter-details/102a8fdf8cbf7467
+Kleydson Rodrigues,"5' 5""",135 lbs.,"67""",Orthodox,"Oct 22, 1995",http://ufcstats.com/fighter-details/102a8fdf8cbf7467
 Paul Rodriguez,"5' 7""",155 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/26eddcda9d6b2ffe
 Ricco Rodriguez,"6' 4""",265 lbs.,--,Orthodox,"Aug 19, 1977",http://ufcstats.com/fighter-details/50cc91ce2982785d
 Manuel Rodriguez,"5' 9""",170 lbs.,--,Orthodox,"Apr 25, 1985",http://ufcstats.com/fighter-details/5a6e4d2f0c76a242
@@ -2836,11 +3237,11 @@ Mike Rodriguez,"6' 4""",205 lbs.,"82""",Southpaw,"Nov 28, 1988",http://ufcstats.
 Marina Rodriguez,"5' 6""",115 lbs.,"65""",Orthodox,"Apr 29, 1987",http://ufcstats.com/fighter-details/cd2c4d30c6e13b47
 Daniel Rodriguez,"6' 1""",170 lbs.,"74""",Southpaw,"Dec 31, 1986",http://ufcstats.com/fighter-details/8a1f3b5c526cd6e6
 Ray Rodriguez,"5' 7""",135 lbs.,"70""",Orthodox,"Dec 10, 1987",http://ufcstats.com/fighter-details/90e0985df05e51bc
-Luis Rodriguez,"5' 6""",125 lbs.,"65""",Orthodox,"May 07, 1999",http://ufcstats.com/fighter-details/f2900678e98f6d6a
+Ronaldo Rodriguez,"5' 6""",125 lbs.,"65""",Orthodox,"May 07, 1999",http://ufcstats.com/fighter-details/f2900678e98f6d6a
 Drako Rodriguez,"5' 8""",135 lbs.,"69""",Orthodox,"Jun 16, 1996",http://ufcstats.com/fighter-details/dc3b9cf7641b7ab6
 Victor Rodriguez,"5' 5""",125 lbs.,"67""",Switch,"Sep 05, 1992",http://ufcstats.com/fighter-details/f6e5972c9d16c40e
 Piera Rodriguez,"5' 3""",115 lbs.,"63""",Orthodox,"Nov 11, 1992",http://ufcstats.com/fighter-details/e375cb5caf4717b6
-Christian Rodriguez,"5' 7""",135 lbs.,"71""",Orthodox,"Dec 17, 1997",http://ufcstats.com/fighter-details/5ec591b78349ba7e
+Christian Rodriguez,"5' 7""",145 lbs.,"71""",Orthodox,"Dec 17, 1997",http://ufcstats.com/fighter-details/5ec591b78349ba7e
 Pete Rodriguez,"5' 9""",170 lbs.,"71""",Switch,"Nov 13, 1996",http://ufcstats.com/fighter-details/776d4262c4da38bf
 Nick Roehrick,"6' 2""",205 lbs.,--,Orthodox,"Jul 06, 1987",http://ufcstats.com/fighter-details/7195e2a932686f82
 Marcos Rogerio de Lima,"6' 1""",253 lbs.,"75""",Orthodox,"Jun 25, 1985",http://ufcstats.com/fighter-details/ab943cd2c3c17825
@@ -2848,7 +3249,7 @@ Brett Rogers,"6' 5""",265 lbs.,"81""",Orthodox,"Feb 17, 1981",http://ufcstats.co
 Brian Rogers,"5' 11""",185 lbs.,--,,"Feb 15, 1984",http://ufcstats.com/fighter-details/f304aff405c4a8fa
 Pete Rogers Jr.,"6' 0""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/36f3d235493d35ad
 Max Rohskopf,"6' 1""",155 lbs.,"71""",Orthodox,"Sep 27, 1994",http://ufcstats.com/fighter-details/59a27d2e6d0802ac
-Marcelo Rojo,"5' 8""",135 lbs.,"71""",Orthodox,"Jul 02, 1988",http://ufcstats.com/fighter-details/2804ce8dadab5770
+Marcelo Rojo,"5' 8""",145 lbs.,"71""",Orthodox,"Jul 02, 1988",http://ufcstats.com/fighter-details/2804ce8dadab5770
 Shane Roller,"5' 10""",155 lbs.,"72""",Orthodox,"Jul 14, 1979",http://ufcstats.com/fighter-details/75e0d3cc2262b732
 Jared Rollins,"5' 9""",170 lbs.,--,Orthodox,"Jan 26, 1977",http://ufcstats.com/fighter-details/c4b6099f0d25f75e
 Tim Roman,"6' 1""",170 lbs.,--,,"Jun 08, 1985",http://ufcstats.com/fighter-details/3b83fec860a45ca1
@@ -2856,9 +3257,11 @@ Alexandr Romanov,"6' 2""",262 lbs.,"75""",Southpaw,"Dec 11, 1990",http://ufcstat
 Ricardo Romero,"6' 0""",205 lbs.,"76""",Orthodox,"Apr 15, 1978",http://ufcstats.com/fighter-details/744e098e065cfdbe
 Yoel Romero,"6' 0""",185 lbs.,"73""",Southpaw,"Apr 30, 1977",http://ufcstats.com/fighter-details/f77c68bb4be8516d
 Anthony Romero,"5' 11""",155 lbs.,"70""",Orthodox,"Feb 25, 1997",http://ufcstats.com/fighter-details/6f81399074fcdbba
+Kaleio Romero,"5' 10""",145 lbs.,"69""",Switch,"Apr 19, 1996",http://ufcstats.com/fighter-details/33df417d0017eb0c
 Mara Romero Borella,"5' 6""",125 lbs.,"69""",Orthodox,"Jun 03, 1986",http://ufcstats.com/fighter-details/82cbb809d5ee565c
-Juancamilo Ronderos,"5' 4""",125 lbs.,--,,"Feb 17, 1995",http://ufcstats.com/fighter-details/4a043165cf47cab2
-Rong Zhu,"5' 9""",155 lbs.,"71""",Orthodox,"Mar 07, 2000",http://ufcstats.com/fighter-details/a13d755965a4ec9f
+Cortavious Romious,"5' 4""",135 lbs.,"68""",Southpaw,"Jan 06, 1994",http://ufcstats.com/fighter-details/8173f134396cb971
+Juancamilo Ronderos,"5' 3""",125 lbs.,"64""",Southpaw,"Feb 17, 1995",http://ufcstats.com/fighter-details/4a043165cf47cab2
+Rongzhu,"5' 9""",155 lbs.,"72""",Orthodox,"Mar 07, 2000",http://ufcstats.com/fighter-details/a13d755965a4ec9f
 Jesse Ronson,"5' 10""",155 lbs.,"70""",Southpaw,"Dec 24, 1985",http://ufcstats.com/fighter-details/5580771f383e141f
 George Roop,"6' 1""",135 lbs.,"72""",Orthodox,"Nov 10, 1981",http://ufcstats.com/fighter-details/3c0437fbeda06962
 Joao Roque,"5' 6""",155 lbs.,--,Orthodox,"Jul 22, 1971",http://ufcstats.com/fighter-details/0f6528b461e47462
@@ -2866,11 +3269,13 @@ Aaron Rosa,"6' 4""",205 lbs.,"77""",Orthodox,"May 28, 1983",http://ufcstats.com/
 Charles Rosa,"5' 9""",145 lbs.,"69""",Switch,"Aug 24, 1986",http://ufcstats.com/fighter-details/40093d1d2d78394e
 Karol Rosa,"5' 5""",135 lbs.,"67""",Orthodox,"Dec 30, 1994",http://ufcstats.com/fighter-details/351c4ec637380ad5
 Jacob Rosales,"5' 11""",155 lbs.,"74""",Orthodox,"Jul 28, 1995",http://ufcstats.com/fighter-details/f7faf5b19e0dec2e
+Raul Rosas Jr.,"5' 9""",135 lbs.,"67""",Switch,"Oct 08, 2004",http://ufcstats.com/fighter-details/fe2babf95de24fb1
 Hilarie Rose,"5' 3""",115 lbs.,"63""",Orthodox,"Nov 11, 1992",http://ufcstats.com/fighter-details/b9163ec845c3bfc8
 Jake Rosholt,"6' 1""",185 lbs.,--,Orthodox,"Feb 09, 1982",http://ufcstats.com/fighter-details/4f2fcbefb668689d
 Jared Rosholt,"6' 2""",265 lbs.,"75""",Orthodox,"Aug 04, 1986",http://ufcstats.com/fighter-details/91ea901c458e95dd
 Kevin Rosier,"6' 4""",275 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/598a58db87b890ee
 Zach Rosol,--,243 lbs.,--,,--,http://ufcstats.com/fighter-details/208b6926916867c7
+Shannon Ross,"5' 6""",125 lbs.,"66""",Switch,"May 12, 1989",http://ufcstats.com/fighter-details/51c655162e462ceb
 Nick Rossborough,"6' 5""",205 lbs.,--,,"Nov 18, 1981",http://ufcstats.com/fighter-details/ff3a915256b899c0
 Kristian Rothaermel,"6' 0""",205 lbs.,--,Open Stance,"Jan 31, 1972",http://ufcstats.com/fighter-details/af49a6c491ca22a3
 Ben Rothwell,"6' 4""",265 lbs.,"78""",Orthodox,"Oct 17, 1981",http://ufcstats.com/fighter-details/bd58d34e39b7b12a
@@ -2880,6 +3285,7 @@ Ronda Rousey,"5' 7""",135 lbs.,"66""",Orthodox,"Feb 01, 1987",http://ufcstats.co
 Ray Routh,"5' 8""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/cba3a2dfbc06ce79
 Roberta Rovel,"5' 8""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/9d7fbf438766791f
 Phil Rowe,"6' 3""",170 lbs.,"80""",Orthodox,"Jul 18, 1990",http://ufcstats.com/fighter-details/8e382b585a92affe
+Cam Rowston,"6' 2""",185 lbs.,"78""",Orthodox,"Jan 19, 1995",http://ufcstats.com/fighter-details/8ebc3a8da015d70c
 Kain Royer,--,185 lbs.,--,,--,http://ufcstats.com/fighter-details/712aa894b3a344df
 Brad Royster,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/09f8c233de88998d
 Brandon Royval,"5' 9""",125 lbs.,"68""",Southpaw,"Aug 16, 1992",http://ufcstats.com/fighter-details/6e15f63b6c2e2c15
@@ -2890,22 +3296,29 @@ Marco Ruas,"6' 1""",210 lbs.,--,Orthodox,"Jan 23, 1961",http://ufcstats.com/figh
 Rodrigo Ruas,"5' 10""",185 lbs.,--,Orthodox,"Oct 06, 1977",http://ufcstats.com/fighter-details/94070f6544c4b2a5
 Rodolfo Rubio Perez,"5' 5""",145 lbs.,--,Orthodox,"Jan 29, 1987",http://ufcstats.com/fighter-details/c4731f43693b96b8
 Gabe Ruediger,"5' 10""",155 lbs.,--,Orthodox,"Aug 29, 1977",http://ufcstats.com/fighter-details/ccba80d4820ef557
+Mauricio Ruffy,"5' 11""",155 lbs.,"75""",Orthodox,"Jun 17, 1996",http://ufcstats.com/fighter-details/9c393e836a852f30
 Eddie Ruiz,"5' 7""",155 lbs.,--,Orthodox,"Jun 10, 1967",http://ufcstats.com/fighter-details/7b9aa973e5c04624
 Anthony Ruiz,"6' 2""",205 lbs.,--,Orthodox,"Nov 03, 1977",http://ufcstats.com/fighter-details/657c21cb133f1445
 Paul Ruiz,"5' 6""",135 lbs.,--,,"Jun 23, 1987",http://ufcstats.com/fighter-details/babc0b19e89cec6e
+Montserrat Conejo Ruiz,"5' 0""",115 lbs.,"61""",Southpaw,"Feb 03, 1993",http://ufcstats.com/fighter-details/1235b31de15d0c6e
 Mike Russow,"6' 1""",255 lbs.,"73""",Orthodox,"Sep 11, 1976",http://ufcstats.com/fighter-details/353de740bb6c7e75
 Bas Rutten,"6' 1""",205 lbs.,--,Orthodox,"Feb 24, 1965",http://ufcstats.com/fighter-details/03688dc3c3af3ac1
+Nursulton Ruziboev,"6' 5""",170 lbs.,"76""",Orthodox,"Nov 19, 1993",http://ufcstats.com/fighter-details/49d2a08964c5eb11
 Casey Ryan,--,185 lbs.,--,,--,http://ufcstats.com/fighter-details/5b1b383265433f51
 Yusup Saadulaev,"5' 6""",135 lbs.,--,,"Mar 31, 1985",http://ufcstats.com/fighter-details/b1669a810fae4220
+Cameron Saaiman,"5' 8""",135 lbs.,"67""",Southpaw,"Dec 20, 2000",http://ufcstats.com/fighter-details/3c8a5200436e19f3
 Pete Sabala,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/7956f026e2672c47
 Danny Sabatello,"5' 10""",135 lbs.,"71""",Orthodox,"Mar 31, 1993",http://ufcstats.com/fighter-details/cb7ee07982de2a28
 Pat Sabatini,"5' 8""",145 lbs.,"70""",Orthodox,"Nov 09, 1990",http://ufcstats.com/fighter-details/b8bbdeff718dbb7d
 Amir Sadollah,"5' 10""",170 lbs.,"75""",Orthodox,"Aug 27, 1980",http://ufcstats.com/fighter-details/2650e2f846a30f64
+Nazim Sadykhov,"5' 10""",155 lbs.,"69""",Southpaw,"May 16, 1994",http://ufcstats.com/fighter-details/ff62013d2fce6d13
 Frankie Saenz,"5' 6""",135 lbs.,"66""",Orthodox,"Aug 12, 1980",http://ufcstats.com/fighter-details/9ba2226646046b63
 Saparbeg Safarov,"6' 1""",185 lbs.,"78""",Orthodox,"Oct 14, 1986",http://ufcstats.com/fighter-details/88d7b6d8230e1f3f
 Tarec Saffiedine,"5' 10""",170 lbs.,"70""",Switch,"Sep 06, 1986",http://ufcstats.com/fighter-details/0749d968e932df53
 Jason Saggo,"5' 11""",155 lbs.,"71""",Orthodox,"Nov 23, 1985",http://ufcstats.com/fighter-details/4ac1ecf8ce59ef23
-Benoit Saint Denis,"5' 11""",170 lbs.,"73""",Southpaw,"Dec 18, 1995",http://ufcstats.com/fighter-details/c2299ec916bc7c56
+Kiru Sahota,"5' 10""",125 lbs.,"73""",Orthodox,"May 28, 1995",http://ufcstats.com/fighter-details/296a120cb880477b
+Tatsuya Saika,"6' 0""",155 lbs.,"73""",Orthodox,"Sep 18, 1990",http://ufcstats.com/fighter-details/cc4e571964b084d4
+Benoit Saint Denis,"5' 11""",155 lbs.,"73""",Southpaw,"Dec 18, 1995",http://ufcstats.com/fighter-details/c2299ec916bc7c56
 Ovince Saint Preux,"6' 3""",205 lbs.,"80""",Southpaw,"Apr 08, 1983",http://ufcstats.com/fighter-details/50db8711c70196cd
 Lukasz Sajewski,"5' 8""",155 lbs.,"71""",Orthodox,"Nov 27, 1990",http://ufcstats.com/fighter-details/fb41432b622992a9
 Yukio Sakaguchi,"5' 9""",185 lbs.,--,Orthodox,"Jul 26, 1973",http://ufcstats.com/fighter-details/94a5aaf573f780ad
@@ -2924,10 +3337,12 @@ John Salgado,"5' 10""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/3e368
 Muslim Salikhov,"5' 11""",170 lbs.,"70""",Orthodox,"Jun 09, 1984",http://ufcstats.com/fighter-details/447f9858ae78f921
 Gabriel Salinas-Jones,"6' 1""",245 lbs.,--,,"Nov 20, 1984",http://ufcstats.com/fighter-details/74d5f71eeb0c66c7
 Brandon Saling,"5' 10""",170 lbs.,--,,"Jan 28, 1986",http://ufcstats.com/fighter-details/a049aa06508b9c7b
+Quillan Salkilld,"6' 0""",155 lbs.,"75""",Orthodox,"Dec 28, 1999",http://ufcstats.com/fighter-details/17734443a833cdf7
 Sean Salmon,"5' 10""",185 lbs.,--,Southpaw,"Sep 11, 1977",http://ufcstats.com/fighter-details/7c0847d3854a95f2
 Boston Salmon,"5' 9""",135 lbs.,"69""",Southpaw,"Nov 20, 1990",http://ufcstats.com/fighter-details/98e946879ba20c0f
 John Salter,"6' 1""",185 lbs.,"74""",Southpaw,"Mar 21, 1985",http://ufcstats.com/fighter-details/010986ee359fb863
-Vinicius Salvador,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/65cdf4ec31143d86
+Vinicius Salvador,"5' 7""",135 lbs.,"70""",Southpaw,"Jul 24, 1996",http://ufcstats.com/fighter-details/65cdf4ec31143d86
+Dylan Salvador,"5' 9""",155 lbs.,"69""",Southpaw,"May 20, 1993",http://ufcstats.com/fighter-details/a7a3fb5f6c67b122
 Josh Samman,"6' 3""",185 lbs.,"79""",Orthodox,"Mar 14, 1988",http://ufcstats.com/fighter-details/9deff9e3e8d94d47
 Johnny Sampaio,"5' 8""",170 lbs.,--,Orthodox,"Sep 11, 1975",http://ufcstats.com/fighter-details/b23388ff8ac6637b
 Josh Sampo,"5' 4""",125 lbs.,"64""",Orthodox,"Jul 24, 1984",http://ufcstats.com/fighter-details/f65dcb22dada2223
@@ -2974,13 +3389,19 @@ Thiago Santos,"6' 2""",205 lbs.,"76""",Orthodox,"Jan 07, 1984",http://ufcstats.c
 Bruno Santos,"5' 9""",185 lbs.,--,Orthodox,"Jul 17, 1987",http://ufcstats.com/fighter-details/da1d8d76404bb6b5
 Andre Santos,"6' 0""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/5b5b78116d1fc3eb
 Gleristone Santos,"5' 9""",145 lbs.,--,,"Aug 20, 1988",http://ufcstats.com/fighter-details/d12ee718fb35c35c
+Yana Santos,"5' 6""",135 lbs.,"68""",Orthodox,"Nov 11, 1989",http://ufcstats.com/fighter-details/3143bf892608139a
 Taila Santos,"5' 6""",125 lbs.,"68""",Orthodox,"Jun 22, 1993",http://ufcstats.com/fighter-details/f7467152fd9f18a2
 Marilia Santos,"5' 4""",125 lbs.,--,Orthodox,"Dec 12, 1992",http://ufcstats.com/fighter-details/4cb79988b2a9bd07
 Edivan Santos,"6' 4""",248 lbs.,"78""",Orthodox,"May 03, 1992",http://ufcstats.com/fighter-details/78719f6663ad9160
-Daniel Santos,"5' 7""",135 lbs.,--,,"Mar 12, 1995",http://ufcstats.com/fighter-details/b67d6bacc68d4c92
+Daniel Santos,"5' 7""",135 lbs.,"67""",Orthodox,"Mar 12, 1995",http://ufcstats.com/fighter-details/b67d6bacc68d4c92
+Gabriel Santos,"5' 9""",145 lbs.,"70""",Orthodox,"Nov 28, 1996",http://ufcstats.com/fighter-details/f2f140ce7532e327
+Luana Santos,"5' 6""",125 lbs.,"67""",Orthodox,"Apr 16, 2000",http://ufcstats.com/fighter-details/5078e1dacf9d25f4
+Djorden Santos,"6' 0""",185 lbs.,"75""",Orthodox,"Aug 01, 1997",http://ufcstats.com/fighter-details/312f7d7b2b2f7de4
+Mairon Santos,"5' 7""",145 lbs.,"72""",Orthodox,"Jun 10, 2000",http://ufcstats.com/fighter-details/480779d7f9a424d3
 Nick Sanzo,"5' 9""",190 lbs.,--,,--,http://ufcstats.com/fighter-details/1d147d4163a6989b
 Bob Sapp,"6' 5""",350 lbs.,--,Orthodox,"Sep 22, 1974",http://ufcstats.com/fighter-details/9f3d6ddef3d3cccc
 Daniel Sarafian,"5' 9""",185 lbs.,"73""",Orthodox,"Aug 21, 1982",http://ufcstats.com/fighter-details/7e47047d0971d566
+Jeka Saragih,"5' 8""",145 lbs.,"69""",Orthodox,"Jan 01, 1995",http://ufcstats.com/fighter-details/57186c150c645200
 Diego Saraiva,"5' 6""",155 lbs.,--,Orthodox,"Apr 23, 1982",http://ufcstats.com/fighter-details/4f4dac51adc1af4f
 Harris Sarmiento,"5' 9""",155 lbs.,--,Orthodox,"Sep 09, 1983",http://ufcstats.com/fighter-details/026b4f7049085842
 Alexander Sarnavskiy,"5' 11""",155 lbs.,--,,"Jan 17, 1989",http://ufcstats.com/fighter-details/2097b1a5ff47dfb0
@@ -2988,18 +3409,22 @@ Yuki Sasaki,"6' 2""",185 lbs.,--,Orthodox,"Sep 12, 1976",http://ufcstats.com/fig
 Kyosuke Sasaki,"5' 7""",183 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/23bd78c3f89bdb54
 Yuta Sasaki,"5' 10""",125 lbs.,"71""",Southpaw,"Oct 07, 1989",http://ufcstats.com/fighter-details/7c3c48cf54a2848e
 Paul Sass,"6' 0""",155 lbs.,"73""",Orthodox,"Aug 04, 1988",http://ufcstats.com/fighter-details/7b143a54451263d9
+Keisuke Sasu,"5' 5""",145 lbs.,"69""",Switch,"Sep 30, 1994",http://ufcstats.com/fighter-details/b7bcf6dfbbb7c16c
 Masaaki Satake,"6' 1""",220 lbs.,--,Orthodox,"Aug 17, 1965",http://ufcstats.com/fighter-details/f4a031ac205ac580
 Takenori Sato,"5' 10""",170 lbs.,--,Southpaw,"Jun 08, 1985",http://ufcstats.com/fighter-details/276c60b14b571dd4
 Takashi Sato,"5' 10""",170 lbs.,"73""",Southpaw,"Jun 09, 1990",http://ufcstats.com/fighter-details/8abac218746e04ca
+Uran Satybaldiev,--,205 lbs.,--,,--,http://ufcstats.com/fighter-details/02f484417a6fa69d
 Jeimeson Saudino,"5' 6""",135 lbs.,--,,"Mar 05, 1991",http://ufcstats.com/fighter-details/f6f9d41669dd3eaa
 Tom Sauer,"6' 1""",263 lbs.,--,,"Nov 11, 1970",http://ufcstats.com/fighter-details/36ab6af06e312b41
 Townsend Saunders,"5' 5""",170 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/20bd6c3e03c46ee6
 Ben Saunders,"6' 2""",170 lbs.,"77""",Orthodox,"Apr 13, 1983",http://ufcstats.com/fighter-details/484acc7b0f856ce9
 Chad W. Saunders,"5' 10""",170 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/4fe9492959834bf7
 Chris Saunders,"5' 8""",155 lbs.,--,,"Mar 11, 1986",http://ufcstats.com/fighter-details/b35a159f525764eb
+Christien Savoie,"5' 11""",170 lbs.,"72""",Orthodox,"Aug 29, 1992",http://ufcstats.com/fighter-details/67f0d1b1b0b39bec
 Lumumba Sayers,"6' 0""",185 lbs.,--,,"Jun 30, 1978",http://ufcstats.com/fighter-details/402ea3b5ee233852
 Matt Sayles,"5' 7""",155 lbs.,"68""",Orthodox,"Feb 21, 1994",http://ufcstats.com/fighter-details/5b8ba8f5512893b1
 Brandon Sayles,"6' 5""",265 lbs.,--,,"Apr 23, 1981",http://ufcstats.com/fighter-details/72b7c071910990b1
+Mikheil Sazhiniani,"6' 0""",205 lbs.,"71""",Orthodox,"Oct 05, 1996",http://ufcstats.com/fighter-details/22a1f83edb865aee
 Mark Scanlon,"5' 9""",170 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/771b60ff889661c8
 Eric Schafer,"6' 3""",185 lbs.,"76""",Orthodox,"Sep 20, 1977",http://ufcstats.com/fighter-details/f59f1d3a2ff13edd
 Kerry Schall,"6' 2""",265 lbs.,--,Orthodox,"Aug 09, 1971",http://ufcstats.com/fighter-details/030f08370fd1c2bb
@@ -3017,16 +3442,19 @@ Daniel Schmitt,--,185 lbs.,--,,--,http://ufcstats.com/fighter-details/bd02e222a6
 Colleen Schneider,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/aa943b9bc00cb0ed
 Matt Schnell,"5' 8""",125 lbs.,"70""",Orthodox,"Jan 15, 1990",http://ufcstats.com/fighter-details/67c1d46f4ed16f9e
 Alex Schoenauer,"6' 3""",185 lbs.,--,Orthodox,"May 05, 1976",http://ufcstats.com/fighter-details/fdfef29ba17ee525
+Bailey Schoenfelder,"6' 3""",265 lbs.,"76""",Orthodox,"Sep 22, 1997",http://ufcstats.com/fighter-details/b0353e7f5038dd09
 Darrill Schoonover,"6' 2""",220 lbs.,--,Orthodox,"Jul 18, 1985",http://ufcstats.com/fighter-details/5a558ba1ff5e9121
 Bob Schrijber,"6' 0""",240 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/d86e913c548c07c2
 Nate Schroeder,"6' 1""",230 lbs.,--,,--,http://ufcstats.com/fighter-details/040426baba8a45e8
 Lacey Schuckman,"5' 3""",125 lbs.,--,,--,http://ufcstats.com/fighter-details/e44c679c30403cba
 Mark Schultz,"5' 9""",200 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/c1684f00c626f4c0
+Wes Schultz,"6' 2""",185 lbs.,"77""",Orthodox,"Aug 09, 1996",http://ufcstats.com/fighter-details/b4443fae47e7eb9d
 Brian Schwartz,"6' 3""",170 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/99c80d2bd5dbe5a9
 Eric Schwartz,--,205 lbs.,--,,--,http://ufcstats.com/fighter-details/79cbdf233e5e0496
 Justin Scoggins,"5' 7""",125 lbs.,"66""",Southpaw,"May 02, 1992",http://ufcstats.com/fighter-details/9fa568ad2bf2cb0b
 Brad Scott,"6' 1""",170 lbs.,"76""",Orthodox,"Jun 24, 1989",http://ufcstats.com/fighter-details/34e552520a934063
 Greg Scott,"5' 9""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/0b235384fe23fc9c
+Louis Lee Scott,--,135 lbs.,--,,"Feb 26, 2000",http://ufcstats.com/fighter-details/4327506eb9ee342f
 Mike Seal,"6' 4""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/0c01568b1ac77bff
 Matt Secor,"6' 0""",170 lbs.,--,,"Sep 26, 1986",http://ufcstats.com/fighter-details/d1ce40aca99a9b70
 Kenneth Seegrist,"6' 0""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/55e94a9b525dcf45
@@ -3034,12 +3462,14 @@ Neil Seery,"5' 4""",125 lbs.,"64""",Orthodox,"Aug 30, 1979",http://ufcstats.com/
 Rony Sefo,"5' 9""",225 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/d6b68eaf4b68b160
 Ray Sefo,"6' 0""",240 lbs.,--,Orthodox,"Feb 15, 1971",http://ufcstats.com/fighter-details/646d5dbe509accd4
 Brendan Seguin,"6' 0""",185 lbs.,--,,"Jul 03, 1976",http://ufcstats.com/fighter-details/e4bb7e483c4ad318
+Tetsuya Seki,"5' 10""",155 lbs.,--,,"Feb 08, 1994",http://ufcstats.com/fighter-details/5e1062e066c601e6
 Stefan Sekulic,"6' 0""",170 lbs.,"75""",Southpaw,"Feb 12, 1992",http://ufcstats.com/fighter-details/348dff4e03bd18c6
 Pete Sell,"5' 11""",170 lbs.,"75""",Orthodox,"Aug 05, 1982",http://ufcstats.com/fighter-details/0359313549d230a1
 Matthew Semelsberger,"6' 1""",170 lbs.,"75""",Switch,"Nov 23, 1992",http://ufcstats.com/fighter-details/4aa58269d0664b5b
 Andrei Semenov,"6' 0""",185 lbs.,--,Orthodox,"Jun 17, 1977",http://ufcstats.com/fighter-details/5f2f0da6fd6a84fd
 Mackens Semerzier,"5' 9""",145 lbs.,"72""",Orthodox,"Nov 03, 1980",http://ufcstats.com/fighter-details/51b1e2fd9872005b
 Brandon Sene,"5' 11""",205 lbs.,--,,"May 21, 1981",http://ufcstats.com/fighter-details/3ed134d85dfbd7b4
+YeDam Seo,"5' 3""",115 lbs.,"63""",Orthodox,"Mar 20, 1992",http://ufcstats.com/fighter-details/762572d67204fadb
 Kim In Seok,"5' 6""",145 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/88b250ba222c3a98
 Ray Seraille,"6' 3""",246 lbs.,--,,--,http://ufcstats.com/fighter-details/2f04c4183523be2e
 Ivan Serati,"6' 0""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/b23fca14c7b79935
@@ -3050,22 +3480,27 @@ Nick Serra,"5' 9""",170 lbs.,--,Orthodox,"Mar 27, 1978",http://ufcstats.com/figh
 Adrian Serrano,"5' 8""",170 lbs.,--,,"Dec 23, 1963",http://ufcstats.com/fighter-details/e7ec11096eac0282
 Fredy Serrano,"5' 3""",125 lbs.,"65""",Orthodox,"Sep 22, 1979",http://ufcstats.com/fighter-details/0ccab7c889ede9ea
 Carl Seumanutafa,"6' 1""",255 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/dadaeb402526dca5
+Igor Severino,"5' 7""",125 lbs.,"69""",Orthodox,"Apr 21, 2003",http://ufcstats.com/fighter-details/6ad8e4296f7522d9
 Dan Severn,"6' 2""",250 lbs.,--,Southpaw,"Jun 08, 1958",http://ufcstats.com/fighter-details/c670aa48827d6be6
 Rosi Sexton,"5' 3""",135 lbs.,--,Orthodox,"Jul 16, 1977",http://ufcstats.com/fighter-details/5dfe71ade71f3a4b
 Scott Shaffer,"5' 7""",145 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/5c38639f860a5542
-Edmen Shahbazyan,"6' 2""",185 lbs.,"74""",Orthodox,"Nov 20, 1997",http://ufcstats.com/fighter-details/4144798612ef96e5
+Edmen Shahbazyan,"6' 3""",185 lbs.,"75""",Orthodox,"Nov 20, 1997",http://ufcstats.com/fighter-details/4144798612ef96e5
 Leon Shahbazyan,"6' 4""",170 lbs.,"74""",Orthodox,"Nov 18, 1995",http://ufcstats.com/fighter-details/9eed2bcc9e0b92af
+Don Shainis,"5' 6""",145 lbs.,"67""",Orthodox,"Sep 16, 1990",http://ufcstats.com/fighter-details/da4628f173337902
 Liliya Shakirova,"5' 4""",125 lbs.,"65""",Orthodox,"Oct 24, 1991",http://ufcstats.com/fighter-details/f300763147320d12
 Kamal Shalorus,"5' 8""",155 lbs.,"68""",Orthodox,"Aug 27, 1972",http://ufcstats.com/fighter-details/ece280745f8727b8
 Ken Shamrock,"6' 1""",205 lbs.,"72""",Orthodox,"Feb 11, 1964",http://ufcstats.com/fighter-details/63b65af1c5cb02cb
 Frank Shamrock,"5' 10""",185 lbs.,--,Orthodox,"Dec 08, 1972",http://ufcstats.com/fighter-details/fcaae0385b514f11
 Shang Zhifa,"5' 7""",125 lbs.,"63""",Orthodox,"Mar 15, 1986",http://ufcstats.com/fighter-details/5a7350645bc9bd6e
+Sean Sharaf,"6' 3""",252 lbs.,"77""",Orthodox,"Jul 11, 1993",http://ufcstats.com/fighter-details/0f3a990526c5e706
+Priya Sharma,"5' 1""",115 lbs.,"59""",Orthodox,"Aug 29, 1991",http://ufcstats.com/fighter-details/5f23eaf9e9c34667
 Jason Sharp,--,205 lbs.,--,,--,http://ufcstats.com/fighter-details/285e32e41f61a5b1
 Eric Shelton,"5' 6""",125 lbs.,"68""",Orthodox,"Feb 02, 1991",http://ufcstats.com/fighter-details/a0c64f272b65d441
 Sean Sherk,"5' 6""",155 lbs.,"67""",Orthodox,"Aug 05, 1973",http://ufcstats.com/fighter-details/029880cdbf5ca089
 Chase Sherman,"6' 4""",250 lbs.,"78""",Orthodox,"Nov 16, 1989",http://ufcstats.com/fighter-details/01b352b6a9074d5c
 Valentina Shevchenko,"5' 5""",125 lbs.,"66""",Southpaw,"Mar 07, 1988",http://ufcstats.com/fighter-details/132deb59abae64b1
 Antonina Shevchenko,"5' 8""",125 lbs.,"67""",Southpaw,"Nov 20, 1984",http://ufcstats.com/fighter-details/d7338bcb141abd2c
+Shi Ming,"5' 2""",115 lbs.,"60""",Orthodox,"Nov 14, 1994",http://ufcstats.com/fighter-details/d683f4870742b273
 Katsuyori Shibata,"6' 0""",168 lbs.,--,Orthodox,"Nov 17, 1979",http://ufcstats.com/fighter-details/d4da8995fc91e7ef
 Jake Shields,"6' 0""",170 lbs.,"72""",Orthodox,"Jan 09, 1979",http://ufcstats.com/fighter-details/fe435e440b5de0ff
 Henrique Shiguemoto,"5' 11""",185 lbs.,"72""",Orthodox,"Jun 22, 1989",http://ufcstats.com/fighter-details/5d1700cfbaafbe06
@@ -3079,12 +3514,14 @@ Josh Shockley,"6' 1""",155 lbs.,--,Orthodox,"Nov 15, 1989",http://ufcstats.com/f
 Josh Shockman,"6' 4""",235 lbs.,--,Southpaw,"Dec 29, 1980",http://ufcstats.com/fighter-details/821cd80aab70d5f9
 Akira Shoji,"5' 8""",195 lbs.,--,Orthodox,"Jan 31, 1974",http://ufcstats.com/fighter-details/b0c95dc8e858452c
 Liudvik Sholinian,"5' 10""",135 lbs.,"71""",Orthodox,"Jan 20, 1990",http://ufcstats.com/fighter-details/1a54231796e24a3f
-Jack Shore,"5' 8""",135 lbs.,"71""",Orthodox,"Feb 06, 1995",http://ufcstats.com/fighter-details/b8a85389d115e35a
+Jack Shore,"5' 8""",145 lbs.,"71""",Orthodox,"Feb 06, 1995",http://ufcstats.com/fighter-details/b8a85389d115e35a
 Landon Showalter,"6' 0""",185 lbs.,--,,"Jun 14, 1976",http://ufcstats.com/fighter-details/35cc17760b06f36d
 Ivan Shtyrkov,"6' 0""",205 lbs.,"74""",Orthodox,"Jun 09, 1988",http://ufcstats.com/fighter-details/1f4b1d7d12601c5f
 Brandon Shuey,"5' 7""",155 lbs.,--,Orthodox,"Feb 01, 1976",http://ufcstats.com/fighter-details/585f9ffdb0cd0466
+Ronal Siahaan,"5' 7""",125 lbs.,"71""",Southpaw,"May 05, 1996",http://ufcstats.com/fighter-details/762226efa2b01654
 Sam Sicilia,"5' 8""",145 lbs.,"67""",Orthodox,"Feb 01, 1986",http://ufcstats.com/fighter-details/b8aef0faf4ce9b31
 Kiril Sidelnikov,"5' 11""",230 lbs.,--,,"Aug 17, 1988",http://ufcstats.com/fighter-details/cf772fb504842dc3
+Serhiy Sidey,"5' 11""",135 lbs.,"72""",Switch,"Jul 04, 1996",http://ufcstats.com/fighter-details/1a2bf44edb8055b6
 Steven Siler,"5' 11""",145 lbs.,"70""",Orthodox,"Feb 15, 1987",http://ufcstats.com/fighter-details/d188a3b817860ec6
 Siala Siliga,"6' 1""",290 lbs.,--,Orthodox,"Oct 08, 1970",http://ufcstats.com/fighter-details/3cf68c1d17f66af7
 Xavier Siller,"5' 5""",125 lbs.,--,,"Jun 06, 1994",http://ufcstats.com/fighter-details/9a08c2753184ac6d
@@ -3111,14 +3548,20 @@ Bruno Silva,"5' 4""",125 lbs.,"65""",Orthodox,"Mar 16, 1990",http://ufcstats.com
 Bruno Silva,"6' 0""",185 lbs.,"74""",Orthodox,"Jul 13, 1989",http://ufcstats.com/fighter-details/12ebd7d157e91701
 Gabriel Silva,"5' 6""",135 lbs.,"71""",Orthodox,"Aug 26, 1994",http://ufcstats.com/fighter-details/002ca196477ce572
 Jacob Silva,"5' 5""",125 lbs.,"67""",Orthodox,"Feb 23, 1988",http://ufcstats.com/fighter-details/f6f2ea21a67be3a7
-Natalia Silva,"5' 4""",125 lbs.,--,,"Feb 03, 1997",http://ufcstats.com/fighter-details/262d32ebda89efc4
+Natalia Silva,"5' 4""",125 lbs.,"65""",Southpaw,"Feb 03, 1997",http://ufcstats.com/fighter-details/262d32ebda89efc4
 Jansey Silva,"6' 2""",185 lbs.,"67""",Orthodox,"May 30, 1995",http://ufcstats.com/fighter-details/0d09efd31eb9fadf
-Maria Silva,"5' 3""",115 lbs.,"65""",Orthodox,"Dec 19, 1995",http://ufcstats.com/fighter-details/4408865b4e65e374
+Maria Silva,"5' 3""",115 lbs.,"64""",Orthodox,"Dec 19, 1995",http://ufcstats.com/fighter-details/4408865b4e65e374
 Karine Silva,"5' 5""",125 lbs.,"67""",Orthodox,"Dec 02, 1993",http://ufcstats.com/fighter-details/9d62c2d8ee151f08
+Erik Silva,"5' 9""",145 lbs.,"71""",Orthodox,"Mar 16, 1987",http://ufcstats.com/fighter-details/21b813b919776d90
+Janaina Silva,"5' 1""",115 lbs.,"60""",Orthodox,"Feb 16, 1992",http://ufcstats.com/fighter-details/4784a5b4a452464a
+Jhonata Silva,"5' 5""",125 lbs.,"66""",Orthodox,"Apr 24, 1997",http://ufcstats.com/fighter-details/4e33534d1e036444
+Jean Silva,"5' 7""",145 lbs.,"69""",Orthodox,"Dec 27, 1996",http://ufcstats.com/fighter-details/52ef95b5860fb28c
+Danny Silva,"5' 11""",145 lbs.,"70""",Switch,"Jan 30, 1997",http://ufcstats.com/fighter-details/d964a59c48381cb6
 Douglas Silva de Andrade,"5' 7""",135 lbs.,"68""",Orthodox,"Jun 22, 1985",http://ufcstats.com/fighter-details/3a314d9fa7c6825d
 Leonardo Silva de Oliveira,"6' 2""",185 lbs.,--,Orthodox,"Apr 23, 1992",http://ufcstats.com/fighter-details/28e088bbcaaa6366
 Marcus Silveira,"6' 3""",242 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/f717b6002486f73f
 Elias Silverio,"5' 11""",155 lbs.,"73""",Orthodox,"Sep 22, 1986",http://ufcstats.com/fighter-details/52ba464d9068d871
+Sim Kai Xiong,"5' 5""",125 lbs.,"66""",Orthodox,"Sep 06, 1997",http://ufcstats.com/fighter-details/79e2cb1e813f881b
 Jamey Simmons,"5' 6""",135 lbs.,"70""",Orthodox,"Sep 11, 1992",http://ufcstats.com/fighter-details/f0fad0e9f3b65752
 Ricky Simon,"5' 6""",135 lbs.,"69""",Orthodox,"Aug 31, 1992",http://ufcstats.com/fighter-details/5987b2458f4b5290
 Aaron Simpson,"6' 0""",170 lbs.,"73""",Orthodox,"Jul 20, 1974",http://ufcstats.com/fighter-details/d5f820c11a121050
@@ -3129,8 +3572,12 @@ Everett Sims,"6' 5""",260 lbs.,"77""",Southpaw,"Sep 04, 1988",http://ufcstats.co
 Lodune Sincaid,"5' 9""",185 lbs.,--,Orthodox,"May 07, 1973",http://ufcstats.com/fighter-details/265589bdd93e7ce5
 Rob Sinclair,"5' 8""",155 lbs.,--,,"Feb 20, 1980",http://ufcstats.com/fighter-details/3b65c9dd39741bc4
 Rory Singer,"6' 2""",185 lbs.,"77""",Orthodox,"May 28, 1976",http://ufcstats.com/fighter-details/546015aa2ad945fd
+Rana Rudra Pratap Singh,"5' 10""",135 lbs.,"69""",Orthodox,"May 09, 1997",http://ufcstats.com/fighter-details/254ed71756cfd18c
+Kiran Singh,"5' 1""",115 lbs.,"65""",Orthodox,"Jul 25, 2000",http://ufcstats.com/fighter-details/f985ca2370a37078
 Elvis Sinosic,"6' 3""",205 lbs.,"77""",Orthodox,"Feb 13, 1971",http://ufcstats.com/fighter-details/817e0bdf08efce2e
 Mitchell Sipe,"6' 2""",245 lbs.,--,Orthodox,"Apr 09, 1996",http://ufcstats.com/fighter-details/71ef1111bf829b82
+Gian Siqueira,"6' 1""",170 lbs.,"74""",Orthodox,"Jun 23, 1994",http://ufcstats.com/fighter-details/a46fdda658fee832
+Jeremia Siregar,"5' 2""",125 lbs.,"63""",Orthodox,"Jul 27, 1991",http://ufcstats.com/fighter-details/a7ac3b1b0c4146db
 AJ Siscoe,"5' 7""",135 lbs.,--,,--,http://ufcstats.com/fighter-details/fce9b4056a8ef559
 Yokthai Sithoar,"5' 7""",143 lbs.,--,,"Dec 25, 1974",http://ufcstats.com/fighter-details/436cdea7bdfdc016
 Jeri Sitzes,"5' 5""",125 lbs.,--,,--,http://ufcstats.com/fighter-details/44a1dd0ef4373edc
@@ -3158,10 +3605,14 @@ Leslie Smith,"5' 9""",135 lbs.,"66""",Orthodox,"Aug 17, 1982",http://ufcstats.co
 Devonte Smith,"5' 9""",155 lbs.,"76""",Orthodox,"Jul 30, 1993",http://ufcstats.com/fighter-details/207773daeb4afa7b
 Cole Smith,"5' 11""",135 lbs.,"67""",Orthodox,"Apr 05, 1989",http://ufcstats.com/fighter-details/56709e66f1c6008f
 Nate Smith,"5' 6""",125 lbs.,"69""",Switch,"Apr 09, 1995",http://ufcstats.com/fighter-details/0bbb69f69c9a2eea
+Braxton Smith,"5' 11""",257 lbs.,"72""",Orthodox,"Jan 01, 1990",http://ufcstats.com/fighter-details/eaa9402e5a7990ad
+Elijah Smith,"5' 9""",135 lbs.,"71""",Orthodox,"Sep 05, 2002",http://ufcstats.com/fighter-details/7478b7f959ba61f5
+Jacobe Smith,"5' 10""",170 lbs.,"72""",Southpaw,"Jan 17, 1996",http://ufcstats.com/fighter-details/85497ffd934ecf7e
 Walter Smith-Cotito,"5' 8""",135 lbs.,--,,--,http://ufcstats.com/fighter-details/625b65b45c1c6888
 Justin Smitley,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/c5776fa8f4bf77aa
 Dmitrii Smoliakov,"6' 2""",253 lbs.,"74""",Switch,"Aug 05, 1982",http://ufcstats.com/fighter-details/75afb06215a07341
 Louis Smolka,"5' 9""",135 lbs.,"68""",Orthodox,"Jul 16, 1991",http://ufcstats.com/fighter-details/d2bc285ead803db0
+Cameron Smotherman,"5' 9""",135 lbs.,"69""",Orthodox,"Sep 17, 1997",http://ufcstats.com/fighter-details/5c84f673b7bb7c15
 Shimon Smotritsky,"6' 2""",170 lbs.,"74""",Orthodox,"Aug 22, 2000",http://ufcstats.com/fighter-details/1b0491ef0f9c965e
 Richie Smullen,"5' 9""",155 lbs.,"68""",Orthodox,"Aug 17, 1991",http://ufcstats.com/fighter-details/f75c5ca0d91b9115
 Devin Smyth,"5' 10""",170 lbs.,"72""",Switch,"Jul 21, 1995",http://ufcstats.com/fighter-details/7684c8137b4545ba
@@ -3169,18 +3620,22 @@ Denis Sobolev,"6' 3""",216 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-detai
 Peter Sobotta,"6' 0""",170 lbs.,"75""",Southpaw,"Jan 11, 1987",http://ufcstats.com/fighter-details/1fcfc3709fe58151
 Renato Sobral,"6' 1""",205 lbs.,"75""",Orthodox,"Sep 07, 1975",http://ufcstats.com/fighter-details/d468288756ae3982
 Rameau Thierry Sokoudjou,"5' 10""",205 lbs.,"78""",Orthodox,"Apr 18, 1984",http://ufcstats.com/fighter-details/d1152823307d7e7c
+Alexander Soldatkin,"6' 2""",250 lbs.,"75""",Orthodox,"Jun 10, 1993",http://ufcstats.com/fighter-details/f1451d605bad178e
 Joe Solecki,"5' 9""",155 lbs.,"70""",Orthodox,"Aug 27, 1993",http://ufcstats.com/fighter-details/af65aa688d13eedf
 Chris Solomon,"5' 11""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/324c7a749128df8d
 Joe Son,"5' 4""",236 lbs.,--,Orthodox,"Nov 22, 1970",http://ufcstats.com/fighter-details/83b743fedde154fb
 Paul Song,--,185 lbs.,--,,--,http://ufcstats.com/fighter-details/9775eabcb1be1a00
 Song Kenan,"6' 0""",170 lbs.,"71""",Orthodox,"Mar 10, 1990",http://ufcstats.com/fighter-details/32490e80ddab1e5a
 Song Yadong,"5' 8""",135 lbs.,"67""",Orthodox,"Dec 02, 1997",http://ufcstats.com/fighter-details/efb96bf3e9ada36f
+YoungJae Song,"5' 7""",145 lbs.,"70""",Orthodox,"Jan 03, 1996",http://ufcstats.com/fighter-details/0efb0d4ebb950fcb
+Emrah Sonmez,"5' 10""",145 lbs.,"71""",Orthodox,"Jun 26, 1992",http://ufcstats.com/fighter-details/fe759b24e344d7eb
 Chael Sonnen,"6' 1""",205 lbs.,"73""",Southpaw,"Apr 03, 1977",http://ufcstats.com/fighter-details/48d1f690b763934c
 Cody Sons,"5' 9""",205 lbs.,--,,--,http://ufcstats.com/fighter-details/3324129f3745b300
 Jin Soo Son,"5' 6""",135 lbs.,"69""",Orthodox,"Apr 01, 1993",http://ufcstats.com/fighter-details/7c9c6a884be167fe
+Benardo Sopaj,"5' 6""",135 lbs.,"66""",Orthodox,"Sep 25, 2000",http://ufcstats.com/fighter-details/b6c37948cb226e8c
 Emiliano Sordi,"6' 2""",205 lbs.,--,Orthodox,"Feb 15, 1991",http://ufcstats.com/fighter-details/4c9b84d559822830
 Sean Soriano,"5' 9""",145 lbs.,"70""",Orthodox,"Oct 06, 1989",http://ufcstats.com/fighter-details/bd5403efbaa445c0
-Punahele Soriano,"5' 11""",185 lbs.,"72""",Southpaw,"Nov 22, 1992",http://ufcstats.com/fighter-details/64facb6cc564262d
+Punahele Soriano,"5' 11""",170 lbs.,"72""",Southpaw,"Nov 22, 1992",http://ufcstats.com/fighter-details/64facb6cc564262d
 Dmitry Sosnovskiy,"6' 3""",240 lbs.,"77""",Orthodox,"Jul 06, 1989",http://ufcstats.com/fighter-details/85ff1b9471d35238
 Ben Sosoli,"6' 0""",265 lbs.,"72""",Southpaw,"Dec 10, 1989",http://ufcstats.com/fighter-details/326f94d6cfb1bf25
 Krzysztof Soszynski,"6' 1""",205 lbs.,"77""",Open Stance,"Aug 02, 1977",http://ufcstats.com/fighter-details/59583ff832fe9d68
@@ -3196,6 +3651,8 @@ Jacare Souza,"6' 1""",185 lbs.,"72""",Orthodox,"Dec 07, 1979",http://ufcstats.co
 Edimilson Souza,"6' 0""",145 lbs.,"74""",Orthodox,"Oct 17, 1984",http://ufcstats.com/fighter-details/6c7020b859c7a3ce
 Livinha Souza,"5' 3""",115 lbs.,"63""",Orthodox,"Mar 11, 1991",http://ufcstats.com/fighter-details/dab8cfbb6b1db10a
 Bruno Souza,"5' 10""",145 lbs.,"70""",Orthodox,"Mar 07, 1996",http://ufcstats.com/fighter-details/0e5c4e72237461bb
+Ketlen Souza,"5' 3""",115 lbs.,"63""",Orthodox,"Aug 18, 1994",http://ufcstats.com/fighter-details/8bd4200561c77a62
+Heraldo Souza,"5' 11""",185 lbs.,"73""",Orthodox,"Dec 15, 1994",http://ufcstats.com/fighter-details/22b43be04d7454d0
 Charon Spain,"5' 9""",155 lbs.,--,,"Mar 11, 1988",http://ufcstats.com/fighter-details/c278e8843b8abfec
 Chris Spang,"6' 2""",170 lbs.,--,Orthodox,"Nov 26, 1987",http://ufcstats.com/fighter-details/411d012af19ecb59
 Andreas Spang,"6' 1""",185 lbs.,--,,"Nov 07, 1978",http://ufcstats.com/fighter-details/b9eb5b4ed07d1525
@@ -3219,7 +3676,7 @@ Georges St-Pierre,"5' 11""",185 lbs.,"76""",Orthodox,"May 19, 1981",http://ufcst
 Bobby Stack,"5' 9""",155 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/6436029b50a9c255
 Andreas Stahl,"5' 11""",170 lbs.,--,Orthodox,"May 20, 1988",http://ufcstats.com/fighter-details/69a400af4420cd6a
 Ron Stallings,"6' 2""",170 lbs.,"75""",Southpaw,"Jan 25, 1983",http://ufcstats.com/fighter-details/6dd758d34da8d254
-Cody Stamann,"5' 6""",145 lbs.,"64""",Orthodox,"Nov 09, 1989",http://ufcstats.com/fighter-details/bf7ad5628363eec9
+Cody Stamann,"5' 6""",135 lbs.,"64""",Orthodox,"Nov 09, 1989",http://ufcstats.com/fighter-details/bf7ad5628363eec9
 Cristina Stanciu,"5' 3""",115 lbs.,--,Orthodox,"Mar 29, 1994",http://ufcstats.com/fighter-details/175852708cb55776
 Brian Stann,"6' 1""",205 lbs.,"74""",Orthodox,"Sep 24, 1980",http://ufcstats.com/fighter-details/579fcdfcabd23a7b
 Josh Stansbury,"6' 2""",205 lbs.,"74""",Orthodox,"Nov 19, 1984",http://ufcstats.com/fighter-details/30ea504870f8597b
@@ -3232,12 +3689,13 @@ Damian Stasiak,"5' 5""",135 lbs.,"70""",Orthodox,"Feb 20, 1990",http://ufcstats.
 Adam Steele,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/16044bd8762cf794
 Dominique Steele,"5' 10""",170 lbs.,"74""",Orthodox,"Jan 27, 1988",http://ufcstats.com/fighter-details/68c11c27d4d56572
 Ricky Steele,"5' 9""",135 lbs.,"74""",Orthodox,"May 26, 1988",http://ufcstats.com/fighter-details/09a6ed4ee97a5606
+Kody Steele,"5' 9""",155 lbs.,"71""",Orthodox,"Apr 21, 1995",http://ufcstats.com/fighter-details/aebaa8cec15b083d
 Eric Steenberg,--,155 lbs.,--,,"Jun 22, 1983",http://ufcstats.com/fighter-details/377bc9dc0b2745f9
 Steve Steinbeiss,"6' 3""",185 lbs.,"75""",Orthodox,"May 05, 1981",http://ufcstats.com/fighter-details/0b5b6876c2a4723f
 Ray Steinbeiss,"5' 11""",170 lbs.,--,Orthodox,"Sep 12, 1979",http://ufcstats.com/fighter-details/6000b5ae6c462142
 Dmitri Stepanov,"6' 3""",217 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/738acab0c6934dd8
 Jeremy Stephens,"5' 9""",145 lbs.,"71""",Orthodox,"May 25, 1986",http://ufcstats.com/fighter-details/18968f97ad34f15c
-Aljamain Sterling,"5' 7""",135 lbs.,"71""",Orthodox,"Jul 31, 1989",http://ufcstats.com/fighter-details/cb696ebfb6598724
+Aljamain Sterling,"5' 7""",145 lbs.,"71""",Orthodox,"Jul 31, 1989",http://ufcstats.com/fighter-details/cb696ebfb6598724
 Marc Stevens,"5' 9""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/310c4d4b2b32796b
 Joe Stevenson,"5' 7""",145 lbs.,"70""",Orthodox,"Jun 15, 1982",http://ufcstats.com/fighter-details/79899ecf62020f6d
 Maia Stevenson,"5' 4""",115 lbs.,"62""",Orthodox,"Mar 19, 1982",http://ufcstats.com/fighter-details/2fee10d5cf86bfca
@@ -3246,12 +3704,13 @@ Darren Stewart,"6' 0""",205 lbs.,"74""",Orthodox,"Dec 30, 1990",http://ufcstats.
 Kyle Stewart,"6' 0""",170 lbs.,"76""",Orthodox,"Jan 31, 1989",http://ufcstats.com/fighter-details/bb61823f76361297
 Alex Stiebling,"6' 2""",205 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/df5a77121ba84a5d
 Tyler Stinson,"6' 3""",170 lbs.,--,,"Jan 17, 1986",http://ufcstats.com/fighter-details/2cf520143e76cd2e
+Navajo Stirling,"6' 4""",205 lbs.,"79""",Orthodox,"Nov 07, 1997",http://ufcstats.com/fighter-details/b4b496ec2197ee3e
 Dan Stittgen,"6' 1""",170 lbs.,--,Orthodox,"Nov 17, 1980",http://ufcstats.com/fighter-details/cc3147b49c7d7d92
 Lazar Stojadinovic,"5' 7""",145 lbs.,"68""",Southpaw,"Mar 22, 1989",http://ufcstats.com/fighter-details/4d25497994da569c
 Denis Stojnic,"6' 0""",245 lbs.,--,Orthodox,"Feb 02, 1980",http://ufcstats.com/fighter-details/a421465acbe59c77
-Julija Stoliarenko,"5' 7""",135 lbs.,"66""",,"Apr 08, 1993",http://ufcstats.com/fighter-details/a78a87d8c2bbb1cb
+Julija Stoliarenko,"5' 7""",125 lbs.,"66""",Orthodox,"Apr 08, 1993",http://ufcstats.com/fighter-details/a78a87d8c2bbb1cb
 Dustin Stoltzfus,"6' 0""",185 lbs.,"75""",Orthodox,"Nov 15, 1991",http://ufcstats.com/fighter-details/71505842fb6455c3
-Niklas Stolze,"6' 0""",170 lbs.,"75""",Switch,"Dec 28, 1992",http://ufcstats.com/fighter-details/62f7097c04311193
+Niklas Stolze,"6' 1""",155 lbs.,"74""",Switch,"Dec 28, 1992",http://ufcstats.com/fighter-details/62f7097c04311193
 Ken Stone,"5' 8""",135 lbs.,"71""",Southpaw,"Oct 08, 1982",http://ufcstats.com/fighter-details/fbf0947399d14323
 Ryan Stonitsch,"5' 9""",170 lbs.,--,Southpaw,"Feb 03, 1977",http://ufcstats.com/fighter-details/8d477c3fbe001f9d
 George Stork,"5' 10""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/61dd409cb40d1a55
@@ -3267,7 +3726,7 @@ Dave Strasser,"5' 10""",170 lbs.,--,Orthodox,"Jul 13, 1969",http://ufcstats.com/
 Daniel Straus,"5' 7""",145 lbs.,"71""",,"Jul 27, 1984",http://ufcstats.com/fighter-details/15347cd4cdf01b03
 Gerald Strebendt,"5' 9""",155 lbs.,--,Orthodox,"Mar 01, 1979",http://ufcstats.com/fighter-details/04f9fe830cf13482
 Sean Strickland,"6' 1""",185 lbs.,"76""",Orthodox,"Feb 27, 1991",http://ufcstats.com/fighter-details/0d8011111be000b2
-Mark Striegl,"5' 8""",135 lbs.,"70""",Southpaw,"Jun 23, 1988",http://ufcstats.com/fighter-details/ef1182eb28c17d4e
+Mark Striegl,"5' 8""",145 lbs.,"70""",Southpaw,"Jun 23, 1988",http://ufcstats.com/fighter-details/ef1182eb28c17d4e
 Hans Stringer,"6' 3""",205 lbs.,--,Orthodox,"Jul 06, 1987",http://ufcstats.com/fighter-details/523f6ad11dbe9b53
 Stefan Struve,"6' 11""",265 lbs.,"84""",Orthodox,"Feb 18, 1988",http://ufcstats.com/fighter-details/ebc1f40e00e0c481
 Josh Stuart,"5' 9""",160 lbs.,--,,--,http://ufcstats.com/fighter-details/601cf40c09090853
@@ -3285,27 +3744,34 @@ Amar Suloev,"5' 9""",183 lbs.,--,Orthodox,"Jul 01, 1976",http://ufcstats.com/fig
 Magomed Sultanakhmedov,"6' 2""",185 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/fe1fdc6be470f773
 Justin Sumter,"6' 2""",185 lbs.,"80""",Southpaw,"Nov 16, 1989",http://ufcstats.com/fighter-details/31f9a1f56cbb6ac5
 Sumudaerji,"5' 8""",125 lbs.,"72""",Southpaw,"Jan 20, 1996",http://ufcstats.com/fighter-details/3cf18e01cb6cbde3
+Rama Supandhi,"5' 5""",125 lbs.,"66""",Southpaw,"Nov 07, 1991",http://ufcstats.com/fighter-details/6d537248fe7cccf1
 Aji Susilo,"5' 10""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/22af3546bd967280
 Jason Suttie,"6' 0""",210 lbs.,--,Orthodox,"Aug 07, 1973",http://ufcstats.com/fighter-details/cc5834a495d1ea08
 Joel Sutton,"5' 11""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/a6a9ab5a824e8f66
 Chad Sutton,"6' 1""",185 lbs.,--,,"Aug 07, 1982",http://ufcstats.com/fighter-details/556347e2b0e33979
+Danilo Suzart,"6' 0""",260 lbs.,--,Orthodox,"Dec 04, 1991",http://ufcstats.com/fighter-details/3d99e5aa85d7576a
 Martin Svensson,"6' 1""",155 lbs.,--,,"Apr 25, 1985",http://ufcstats.com/fighter-details/bcad7223af3c19da
 Daniel Swain,"5' 9""",145 lbs.,"70""",Orthodox,"Jan 30, 1991",http://ufcstats.com/fighter-details/cc39185f2d7d89e4
 Cub Swanson,"5' 8""",145 lbs.,"70""",Orthodox,"Nov 02, 1983",http://ufcstats.com/fighter-details/d247691a6c0e9034
 Mike Swick,"6' 1""",170 lbs.,"77""",Orthodox,"Jun 19, 1979",http://ufcstats.com/fighter-details/9fe85152f351e737
 Floyd Sword,"6' 0""",185 lbs.,--,Orthodox,"Aug 24, 1976",http://ufcstats.com/fighter-details/5330fe7e4c3af81c
+Oumar Sy,"6' 4""",205 lbs.,"83""",Orthodox,"Nov 21, 1995",http://ufcstats.com/fighter-details/46e2011d92463b7e
+Klaudia Sygula,--,135 lbs.,--,,"Dec 30, 1998",http://ufcstats.com/fighter-details/9f5e3c20ce40b344
 Bentley Syler,"5' 4""",125 lbs.,--,Orthodox,"Dec 22, 1982",http://ufcstats.com/fighter-details/abd2109bc4cb0291
 Kevin Syler,"5' 9""",155 lbs.,"71""",Switch,"Jul 29, 1993",http://ufcstats.com/fighter-details/9094a881a7513de3
 Leo Sylvest,"5' 11""",205 lbs.,--,Orthodox,"Sep 03, 1973",http://ufcstats.com/fighter-details/58a36b4ccf5dc30e
 Tony Sylvester,"6' 1""",225 lbs.,--,Southpaw,"Jan 27, 1978",http://ufcstats.com/fighter-details/87b7df65c30008c4
 Tim Sylvia,"6' 8""",265 lbs.,"80""",Orthodox,"Mar 05, 1976",http://ufcstats.com/fighter-details/2a542ee8a8b83559
+Kevin Szaflarski,"6' 5""",260 lbs.,"77""",Orthodox,"Dec 30, 1994",http://ufcstats.com/fighter-details/d2d05dda5f887f87
+Bartosz Szewczyk,"6' 4""",205 lbs.,"73""",Orthodox,"Sep 18, 1997",http://ufcstats.com/fighter-details/224050896306f00c
 Osamu Tachihikari,"6' 5""",300 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/e7bc606d269896aa
 Amber Tackett,--,115 lbs.,--,,--,http://ufcstats.com/fighter-details/bb01bc3c57f39b04
 Eugenio Tadeu,"5' 8""",160 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/f70144caea5c4c80
 Justin Tafa,"6' 0""",264 lbs.,"74""",Southpaw,"Dec 13, 1993",http://ufcstats.com/fighter-details/e13abac8089a801a
-Junior Tafa,--,--,--,,"Sep 21, 1996",http://ufcstats.com/fighter-details/c15fa95b9a12fde4
+Junior Tafa,"6' 3""",240 lbs.,"75""",Orthodox,"Sep 21, 1996",http://ufcstats.com/fighter-details/c15fa95b9a12fde4
 Khalid Taha,"5' 5""",135 lbs.,"69""",Orthodox,"Feb 15, 1992",http://ufcstats.com/fighter-details/b4537562f88ac582
 Joe Taimanglo,"5' 4""",135 lbs.,--,,"Jun 27, 1984",http://ufcstats.com/fighter-details/9bf126927843e184
+Tatsuro Taira,"5' 7""",125 lbs.,"70""",Orthodox,"Jan 27, 2000",http://ufcstats.com/fighter-details/4461d7e47375a895
 Mairbek Taisumov,"5' 9""",155 lbs.,"73""",Orthodox,"Aug 08, 1988",http://ufcstats.com/fighter-details/8f5c8850b2484173
 Nobuhiko Takada,"6' 0""",220 lbs.,--,Southpaw,"Apr 12, 1962",http://ufcstats.com/fighter-details/a25b71fe5e31fa97
 Yoshiki Takahashi,"5' 11""",199 lbs.,--,Southpaw,"Mar 13, 1969",http://ufcstats.com/fighter-details/6420efac0578988b
@@ -3315,7 +3781,9 @@ Hiroyuki Takaya,"5' 6""",139 lbs.,--,Orthodox,"Jun 10, 1977",http://ufcstats.com
 Yoshihiro Takayama,"6' 5""",280 lbs.,--,Orthodox,"Sep 19, 1968",http://ufcstats.com/fighter-details/d856a0080ac09ed7
 Makoto Takimoto,"5' 7""",205 lbs.,--,Southpaw,"Dec 08, 1979",http://ufcstats.com/fighter-details/a7724f51e32e763e
 Oleg Taktarov,"6' 0""",210 lbs.,--,Orthodox,"Aug 26, 1967",http://ufcstats.com/fighter-details/1dc56b59cb28425d
+Payton Talbott,"5' 10""",135 lbs.,"70""",Switch,"Sep 09, 1998",http://ufcstats.com/fighter-details/6e743a33d56bdaa4
 Nordine Taleb,"6' 1""",170 lbs.,"74""",Orthodox,"Jun 10, 1981",http://ufcstats.com/fighter-details/49858bf46dabf6fb
+Murtaza Talha,"6' 0""",205 lbs.,"74""",Orthodox,"Jul 10, 1996",http://ufcstats.com/fighter-details/6aab5c20395ee722
 Tsuyoshi Tamakairiki,"6' 0""",220 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/eaa0a728cc91ef60
 Eli Tamez,"5' 7""",135 lbs.,--,,"Aug 22, 1985",http://ufcstats.com/fighter-details/bfd4d50591033a1f
 Kiyoshi Tamura,"5' 11""",185 lbs.,--,Southpaw,"Dec 17, 1969",http://ufcstats.com/fighter-details/30e8b4505f5ccf92
@@ -3325,13 +3793,17 @@ Jason Tan,"5' 10""",170 lbs.,--,Orthodox,"Dec 17, 1981",http://ufcstats.com/figh
 Akihito Tanaka,--,--,--,Southpaw,--,http://ufcstats.com/fighter-details/1bf49bf829964144
 Michinori Tanaka,"5' 5""",135 lbs.,"67""",Orthodox,"Oct 04, 1990",http://ufcstats.com/fighter-details/64788ee44b062ded
 Evan Tanner,"6' 0""",185 lbs.,"74""",Orthodox,"Feb 11, 1971",http://ufcstats.com/fighter-details/8f2d9ee27f206f1f
+Kasey Tanner,"5' 7""",135 lbs.,"69""",Orthodox,"Jan 11, 1992",http://ufcstats.com/fighter-details/078b732efa497f49
+Otari Tanzilovi,"5' 10""",135 lbs.,"70""",Orthodox,"Apr 09, 1998",http://ufcstats.com/fighter-details/b9124c308671e303
 Manny Tapia,"5' 5""",135 lbs.,"67""",Orthodox,"Mar 14, 1981",http://ufcstats.com/fighter-details/0eec866a077889f0
 Gary Tapusoa,"5' 7""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/37ac9e0f4fc86171
 Miesha Tate,"5' 6""",135 lbs.,"65""",Orthodox,"Aug 18, 1986",http://ufcstats.com/fighter-details/b96619b3acd7d9da
+Aaron Tau,"5' 4""",135 lbs.,"66""",Switch,"Aug 21, 1993",http://ufcstats.com/fighter-details/7abf7f8778472b7b
 Deividas Taurosevicius,"5' 9""",145 lbs.,"68""",Southpaw,"Aug 28, 1977",http://ufcstats.com/fighter-details/ef927e4fe2117ab8
 Thiago Tavares,"5' 7""",145 lbs.,"70""",Orthodox,"Nov 08, 1984",http://ufcstats.com/fighter-details/8a59d346dc976a10
 Jeremy Tavares,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/681d07e328798ec0
 Brad Tavares,"6' 1""",185 lbs.,"74""",Orthodox,"Dec 21, 1987",http://ufcstats.com/fighter-details/0c6d9ea8306c029e
+Ramon Taveras,"5' 8""",135 lbs.,"70""",Southpaw,"Jan 09, 1994",http://ufcstats.com/fighter-details/c5ccd878231c5407
 Paul Taylor,"6' 0""",155 lbs.,"72""",Orthodox,"Dec 15, 1979",http://ufcstats.com/fighter-details/9b74de674c355425
 Jesse Taylor,"6' 0""",170 lbs.,"73""",Orthodox,"Jan 02, 1983",http://ufcstats.com/fighter-details/dd992d569aaebee6
 Torrance Taylor,"5' 7""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/88e53ec16b801740
@@ -3340,11 +3812,14 @@ Anthony Taylor,"5' 7""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/637a
 Danielle Taylor,"5' 0""",115 lbs.,"60""",Orthodox,"Oct 25, 1989",http://ufcstats.com/fighter-details/b76c6268dc1d3c05
 J.T Taylor,"5' 10""",--,--,,--,http://ufcstats.com/fighter-details/17c6e35e4da505b0
 James Te Huna,"6' 2""",185 lbs.,"75""",Orthodox,"Sep 29, 1981",http://ufcstats.com/fighter-details/f5431394fb284bb9
+Cam Teague,"5' 10""",145 lbs.,"69""",Orthodox,"Feb 13, 1998",http://ufcstats.com/fighter-details/b47c9ea5f2895d6e
 Shawn Teed,"6' 5""",265 lbs.,--,Orthodox,"Feb 13, 1992",http://ufcstats.com/fighter-details/5bb70ebd65075c5c
 Glover Teixeira,"6' 2""",205 lbs.,"76""",Orthodox,"Oct 28, 1979",http://ufcstats.com/fighter-details/7ff97850e8c32bda
 John Teixeira,"5' 7""",145 lbs.,--,Orthodox,"Nov 18, 1986",http://ufcstats.com/fighter-details/86061eaba822bfea
 Ewerton Teixeira,"6' 1""",242 lbs.,--,,"Feb 13, 1982",http://ufcstats.com/fighter-details/de9e331b3e6bae70
+Tallison Teixeira,"6' 7""",258 lbs.,"83""",Orthodox,"Dec 07, 1999",http://ufcstats.com/fighter-details/17923f676f100e16
 Tra Telligman,"6' 2""",233 lbs.,--,Orthodox,"Feb 07, 1965",http://ufcstats.com/fighter-details/1dab0d1d81dd06db
+Ramazan Temirov,"5' 4""",125 lbs.,"63""",Orthodox,"Jan 31, 1997",http://ufcstats.com/fighter-details/7d0a1968b38ca439
 Taneisha Tennant,"5' 7""",145 lbs.,"70""",Orthodox,"Jun 15, 1989",http://ufcstats.com/fighter-details/87911d22a79d3203
 Herman Terrado,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/61d6368013f8637f
 Dave Terrel,"5' 8""",170 lbs.,--,Southpaw,"May 10, 1978",http://ufcstats.com/fighter-details/b9aa0024f295609e
@@ -3355,6 +3830,7 @@ David Teymur,"5' 9""",155 lbs.,"73""",Southpaw,"May 01, 1989",http://ufcstats.co
 Daniel Teymur,"5' 5""",145 lbs.,"69""",Orthodox,"Feb 03, 1988",http://ufcstats.com/fighter-details/fbf0537e420e698e
 Motonobu Tezuka,"5' 7""",135 lbs.,--,Southpaw,"Aug 29, 1987",http://ufcstats.com/fighter-details/d34636a85f0f4c90
 Jason Thacker,"5' 10""",185 lbs.,--,Orthodox,"Aug 18, 1975",http://ufcstats.com/fighter-details/f0264252e191da22
+Alexia Thainara,"5' 4""",115 lbs.,"67""",,"Nov 20, 1995",http://ufcstats.com/fighter-details/545092d13c67aa49
 Brandon Thatch,"6' 2""",170 lbs.,"74""",Switch,"Jul 11, 1985",http://ufcstats.com/fighter-details/638cfec7ec559d6e
 Elias Theodorou,"6' 1""",185 lbs.,"75""",Orthodox,"May 31, 1988",http://ufcstats.com/fighter-details/34f88592c0ab7a54
 Nik Theotikos,--,185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/ca936c67687789e9
@@ -3366,7 +3842,7 @@ Joel Thomas ,"5' 10""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/2b33e
 Treston Thomison,"5' 8""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/ed5f04f833459877
 Nick Thompson,"6' 1""",170 lbs.,"74""",Orthodox,"Jun 23, 1981",http://ufcstats.com/fighter-details/7d3caf0f96f1b33d
 James Thompson,"6' 5""",265 lbs.,--,Orthodox,"Dec 16, 1978",http://ufcstats.com/fighter-details/9e30f69cc0869301
-Oli Thompson,"6' 1""",242 lbs.,--,Orthodox,"Jan 02, 1980",http://ufcstats.com/fighter-details/dcdd511ff757f15c
+Oli Thompson,"6' 1""",242 lbs.,"75""",Orthodox,"Jan 02, 1980",http://ufcstats.com/fighter-details/dcdd511ff757f15c
 Stephen Thompson,"6' 0""",170 lbs.,"75""",Orthodox,"Feb 11, 1983",http://ufcstats.com/fighter-details/4a28cb716c19157a
 Josh Thomson,"5' 10""",155 lbs.,"71""",Orthodox,"Sep 21, 1978",http://ufcstats.com/fighter-details/a566371ba2ad7152
 Simeon Thoresen,"6' 1""",170 lbs.,"79""",Orthodox,"Mar 14, 1984",http://ufcstats.com/fighter-details/fea8acf9bfcf09ec
@@ -3376,30 +3852,35 @@ Chris Tickle,"5' 9""",155 lbs.,--,,"Feb 01, 1982",http://ufcstats.com/fighter-de
 Nolan Ticman,"5' 6""",125 lbs.,--,Orthodox,"May 17, 1988",http://ufcstats.com/fighter-details/9eb069062a0cfc13
 Darren Till,"6' 0""",185 lbs.,"74""",Southpaw,"Dec 24, 1992",http://ufcstats.com/fighter-details/9ce6d5a03af801b7
 Brett Tillis,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/7b461ccae8270207
+Denis Tiuliulin,"6' 1""",185 lbs.,"77""",Orthodox,"May 17, 1988",http://ufcstats.com/fighter-details/0112352cb32f5026
 Ryan Tobar,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/57481f1f10530c61
 Andrew Todhunter,"6' 0""",185 lbs.,--,Switch,"Nov 30, 1987",http://ufcstats.com/fighter-details/274ca7b799b402cc
 Dusko Todorovic,"6' 1""",185 lbs.,"74""",Orthodox,"May 19, 1994",http://ufcstats.com/fighter-details/866fd7b1a6c90e7f
+Tuco Tokkos,"6' 4""",205 lbs.,"76""",Orthodox,"Jun 30, 1990",http://ufcstats.com/fighter-details/3e8118c1ab52f211
 Hideo Tokoro,"5' 7""",135 lbs.,--,Orthodox,"Aug 22, 1977",http://ufcstats.com/fighter-details/2d5fbe2103f97053
 Anatoly Tokov,"5' 10""",185 lbs.,--,,"Feb 17, 1990",http://ufcstats.com/fighter-details/679ae8c4fd022c6b
 Kazuki Tokudome,"5' 11""",155 lbs.,"73""",Southpaw,"Mar 04, 1987",http://ufcstats.com/fighter-details/c4af2feb4b58bc3b
+Puja Tomar,"5' 4""",115 lbs.,"59""",Southpaw,"Dec 05, 1993",http://ufcstats.com/fighter-details/19f8a2f6eecd92ac
 Tyler Toner,"5' 8""",145 lbs.,"70""",Orthodox,"Mar 31, 1983",http://ufcstats.com/fighter-details/8e893f269d5696b2
 James Toney,"5' 9""",220 lbs.,--,Orthodox,"Aug 24, 1968",http://ufcstats.com/fighter-details/d10b35152277cf98
 Masanori Tonooka,"5' 8""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/9de7c97e1c0d7927
 Carl Toomey,--,--,--,,--,http://ufcstats.com/fighter-details/5ee87e0432205755
 Ilia Topuria,"5' 7""",145 lbs.,"69""",Orthodox,"Jan 21, 1997",http://ufcstats.com/fighter-details/54f64b5e283b0ce7
+Aleksandre Topuria,--,135 lbs.,--,,"Jan 28, 1996",http://ufcstats.com/fighter-details/4a6dff1b260bcf61
 Anthony Torres,"5' 8""",170 lbs.,--,Orthodox,"Jul 31, 1978",http://ufcstats.com/fighter-details/918d9d89d4d52acc
 Miguel Torres,"5' 9""",135 lbs.,"76""",Orthodox,"Jan 18, 1981",http://ufcstats.com/fighter-details/33b2f68ef95252e0
 Ronys Torres,"5' 7""",155 lbs.,--,Orthodox,"Aug 13, 1975",http://ufcstats.com/fighter-details/cce79e827569f26e
 Haven Torres,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/1ff10dee2f7ae60c
-Tecia Torres,"5' 1""",115 lbs.,"60""",Orthodox,"Aug 16, 1989",http://ufcstats.com/fighter-details/31ef8b67e13495b3
 Alex Torres,"5' 10""",145 lbs.,--,Orthodox,"May 29, 1988",http://ufcstats.com/fighter-details/e4e0f310b3cf23a8
 Abram Torres,"5' 10""",170 lbs.,--,,"Oct 29, 1982",http://ufcstats.com/fighter-details/e175a261a280f7cb
 Jose Torres,"5' 4""",125 lbs.,"65""",Orthodox,"Aug 02, 1992",http://ufcstats.com/fighter-details/d2036f31c035e0d1
 Desmond Torres,"5' 6""",135 lbs.,"69""",Orthodox,"Jan 06, 1997",http://ufcstats.com/fighter-details/971aebf56267de20
-Manuel Torres,"5' 10""",155 lbs.,"73""",,"Mar 25, 1995",http://ufcstats.com/fighter-details/2e7878927067fdca
+Manuel Torres,"5' 10""",155 lbs.,"73""",Switch,"Mar 25, 1995",http://ufcstats.com/fighter-details/2e7878927067fdca
+Eduardo Torres Caut,"5' 7""",135 lbs.,"70""",Orthodox,"Apr 26, 1995",http://ufcstats.com/fighter-details/c8d46028907bcece
 Salim Touahri,"5' 10""",170 lbs.,"72""",Orthodox,"Sep 28, 1989",http://ufcstats.com/fighter-details/cbf1c7ba5408a66f
 Dequan Townsend,"6' 3""",205 lbs.,"79""",Orthodox,"May 11, 1986",http://ufcstats.com/fighter-details/3f7dab21b6c971bc
 Minoru Toyonaga,"5' 11""",195 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/04076783ca83d6ae
+Slim Trabelsi,"6' 3""",235 lbs.,--,,"May 09, 1993",http://ufcstats.com/fighter-details/ff2ec83f44000f78
 Roberto Traven,"6' 3""",227 lbs.,--,Orthodox,"Sep 16, 1968",http://ufcstats.com/fighter-details/20ec0061400178ca
 Bryan Travers,--,155 lbs.,--,,"Apr 11, 1983",http://ufcstats.com/fighter-details/008cf84faae9c7a5
 Alexander Trevino,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/73abb7a5c57fb443
@@ -3409,12 +3890,13 @@ Frank Trigg,"5' 9""",170 lbs.,"71""",Southpaw,"May 07, 1972",http://ufcstats.com
 Francisco Trinaldo,"5' 9""",170 lbs.,"70""",Southpaw,"Aug 24, 1978",http://ufcstats.com/fighter-details/a8283a4f415e1eb9
 Damien Trites,"5' 11""",165 lbs.,--,,"Aug 23, 1979",http://ufcstats.com/fighter-details/cb1c09c8126dbee0
 Michael Trizano,"5' 11""",145 lbs.,"71""",Orthodox,"Dec 31, 1991",http://ufcstats.com/fighter-details/5bf31a46becc1204
-Antonio Trocoli,"6' 5""",205 lbs.,"82""",Orthodox,"Dec 06, 1990",http://ufcstats.com/fighter-details/6d48a2df51749d91
+Antonio Trocoli,"6' 5""",185 lbs.,"80""",Orthodox,"Dec 06, 1990",http://ufcstats.com/fighter-details/6d48a2df51749d91
 Tor Troeng,"6' 2""",185 lbs.,--,Orthodox,"Jan 25, 1983",http://ufcstats.com/fighter-details/8abf70f79e9e27c2
 Aaron Trujillo,"5' 5""",125 lbs.,--,,--,http://ufcstats.com/fighter-details/cc18abc046b382c9
 Reynaldo Trujillo,"5' 9""",155 lbs.,--,,"Jan 01, 1982",http://ufcstats.com/fighter-details/e6b233a007cb06c4
 Abel Trujillo,"5' 8""",155 lbs.,"70""",Orthodox,"Sep 18, 1983",http://ufcstats.com/fighter-details/e14b5aa06eea9653
 Arman Tsarukyan,"5' 7""",155 lbs.,"72""",Orthodox,"Oct 11, 1996",http://ufcstats.com/fighter-details/eae48ff31db420c2
+Rei Tsuruya,"5' 6""",125 lbs.,"68""",Orthodox,"Jun 22, 2002",http://ufcstats.com/fighter-details/2f43a3e82661fa99
 Chris Tuchscherer,"6' 2""",258 lbs.,"76""",Orthodox,"Sep 08, 1975",http://ufcstats.com/fighter-details/df05aa15b2d66f57
 Jon Tuck,"5' 11""",155 lbs.,"73""",Orthodox,"Aug 28, 1984",http://ufcstats.com/fighter-details/53ec9cb470e1a4ea
 Gavin Tucker,"5' 6""",145 lbs.,"66""",Southpaw,"Jun 17, 1986",http://ufcstats.com/fighter-details/da816417a579a0bd
@@ -3422,17 +3904,19 @@ Jumabieke Tuerxun,"5' 7""",135 lbs.,--,Orthodox,"Apr 17, 1986",http://ufcstats.c
 Tom Tuggle,"6' 2""",250 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/b9aa7d230865b5fe
 Blair Tugman,"6' 0""",135 lbs.,--,,--,http://ufcstats.com/fighter-details/63f8775391301891
 Tai Tuivasa,"6' 2""",264 lbs.,"75""",Southpaw,"Mar 16, 1993",http://ufcstats.com/fighter-details/c62fbc117d57b943
-Zubaira Tukhugov,"5' 8""",145 lbs.,"68""",Orthodox,"Jan 15, 1991",http://ufcstats.com/fighter-details/aceffa19749c4dc0
+Zubaira Tukhugov,"5' 8""",155 lbs.,"68""",Orthodox,"Jan 15, 1991",http://ufcstats.com/fighter-details/aceffa19749c4dc0
 Teila Tuli,"6' 0""",430 lbs.,--,Orthodox,"Jun 14, 1969",http://ufcstats.com/fighter-details/96eff1a628adcc7f
+Marco Tulio,"6' 0""",185 lbs.,"74""",Orthodox,"Jun 13, 1994",http://ufcstats.com/fighter-details/9384e71bca6c409d
+Nyamjargal Tumendemberel,"5' 7""",125 lbs.,"71""",Orthodox,"Mar 22, 1998",http://ufcstats.com/fighter-details/17cb6d8e8187f304
 Albert Tumenov,"5' 11""",170 lbs.,"73""",Orthodox,"Dec 26, 1991",http://ufcstats.com/fighter-details/ff6a1f63c254127e
-Maimaiti Tuohati,--,--,--,,--,http://ufcstats.com/fighter-details/31319179c9b1e6e7
 Ricky Turcios,"5' 9""",135 lbs.,"71""",Orthodox,"Jun 05, 1993",http://ufcstats.com/fighter-details/cd3d7e37ff2d679c
-Anton Turkalj,"6' 4""",205 lbs.,--,,"Jun 10, 1996",http://ufcstats.com/fighter-details/82529ce93cd9a2cf
-Wellington Turman,"6' 0""",185 lbs.,"72""",Orthodox,"Jul 22, 1996",http://ufcstats.com/fighter-details/4dcfb28c011c11b2
+Anton Turkalj,"6' 4""",205 lbs.,"78""",Orthodox,"Jun 10, 1996",http://ufcstats.com/fighter-details/82529ce93cd9a2cf
+Wellington Turman,"6' 0""",170 lbs.,"72""",Orthodox,"Jul 22, 1996",http://ufcstats.com/fighter-details/4dcfb28c011c11b2
 Courtney Turner,"6' 2""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/56f4b81ec4db61af
 Jalin Turner,"6' 3""",155 lbs.,"77""",Southpaw,"May 18, 1995",http://ufcstats.com/fighter-details/4d8fa64202cee4c1
 Austin Tweedy,"5' 9""",155 lbs.,--,Orthodox,"Sep 25, 1990",http://ufcstats.com/fighter-details/885adaff8fe15cf7
 Marcin Tybura,"6' 3""",249 lbs.,"78""",Orthodox,"Nov 09, 1985",http://ufcstats.com/fighter-details/c9cf753cfdf77fc2
+Takeru Uchida,"5' 5""",125 lbs.,"68""",Southpaw,"Sep 30, 2002",http://ufcstats.com/fighter-details/1d76f07ffdd765c2
 Alberto Uda,"6' 3""",185 lbs.,--,Orthodox,"Aug 08, 1984",http://ufcstats.com/fighter-details/8f2deefe8c5dfb5d
 Ryuki Ueyama,"5' 11""",180 lbs.,--,Southpaw,"Apr 17, 1976",http://ufcstats.com/fighter-details/bcd124bcd3d5be46
 Christian Uflacker,"5' 11""",170 lbs.,--,,"Aug 04, 1985",http://ufcstats.com/fighter-details/10ccf4ec9913cadc
@@ -3447,26 +3931,33 @@ Kengo Ura,"5' 9""",165 lbs.,--,,"Jun 20, 1981",http://ufcstats.com/fighter-detai
 Logan Urban,"6' 0""",170 lbs.,"72""",Orthodox,"Apr 22, 1994",http://ufcstats.com/fighter-details/5e23f30e9c6ed74e
 Hector Urbina,"5' 11""",170 lbs.,"73""",Orthodox,"Sep 17, 1987",http://ufcstats.com/fighter-details/4b8fb0453a596b8e
 Elias Urbina,"6' 3""",185 lbs.,"77""",Southpaw,"Oct 09, 1993",http://ufcstats.com/fighter-details/47fcdcaccb58ca80
-Gilbert Urbina,"6' 3""",185 lbs.,"75""",Orthodox,"Apr 05, 1996",http://ufcstats.com/fighter-details/b12fb759e02378de
+Gilbert Urbina,"6' 3""",170 lbs.,"75""",Orthodox,"Apr 05, 1996",http://ufcstats.com/fighter-details/b12fb759e02378de
 Nick Urso,"5' 6""",125 lbs.,"66""",Southpaw,"Sep 26, 1985",http://ufcstats.com/fighter-details/e78c4c3d329c531b
 Yasuhiro Urushitani,"5' 5""",125 lbs.,--,Southpaw,"Sep 08, 1976",http://ufcstats.com/fighter-details/c34e5849184b08c3
+Sho Patrick Usami,"5' 9""",155 lbs.,"70""",Orthodox,"May 08, 2000",http://ufcstats.com/fighter-details/fe30c5f5cc3e028b
 Kamaru Usman,"6' 0""",170 lbs.,"76""",Switch,"May 11, 1987",http://ufcstats.com/fighter-details/f1b2aa7853d1ed6e
+Mohammed Usman,"6' 2""",239 lbs.,"79""",Orthodox,"Apr 01, 1989",http://ufcstats.com/fighter-details/da7f113b5ea39c43
 Darren Uyenoyama,"5' 6""",125 lbs.,"65""",Orthodox,"Oct 15, 1979",http://ufcstats.com/fighter-details/6546af7ab545b90c
 Richie Vaculik,"5' 6""",125 lbs.,"69""",Orthodox,"Jun 19, 1983",http://ufcstats.com/fighter-details/54578e5927adea53
+Artem Vakhitov,"6' 1""",205 lbs.,"75""",Orthodox,"Apr 04, 1991",http://ufcstats.com/fighter-details/43e549b803ec7375
 Egidijus Valavicius,"6' 0""",200 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/fc1868f56d3036eb
 Genaro Valdez,"5' 9""",155 lbs.,"72""",Orthodox,"Jan 16, 1992",http://ufcstats.com/fighter-details/cda1099995b46cc2
 Charlie Valencia,"5' 3""",135 lbs.,"64""",Orthodox,"Oct 31, 1974",http://ufcstats.com/fighter-details/8a0be41c0380188d
+Robert Valentin,"6' 2""",185 lbs.,"77""",Orthodox,"Mar 31, 1995",http://ufcstats.com/fighter-details/0cd0456d6029cec2
 Victor Valenzuela,"5' 10""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/de277a4abcfeea46
+Ivan Valenzuela,"6' 2""",185 lbs.,"77""",Orthodox,"Nov 17, 1992",http://ufcstats.com/fighter-details/45b82ebf0b9e0fd2
 Timur Valiev,"5' 6""",135 lbs.,"67""",Orthodox,"Jan 19, 1990",http://ufcstats.com/fighter-details/45e738622ea2c02c
 Victor Valimaki,"6' 0""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/663b76da637402c3
 Andrew Valladerez,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/2a898bf9fb7710b3
+Kevin Vallejos,"5' 7""",145 lbs.,"68""",Switch,"Dec 08, 2001",http://ufcstats.com/fighter-details/239d8e5359022f3b
 Isaac Vallie-Flagg,"5' 8""",155 lbs.,"70""",Orthodox,"Apr 08, 1978",http://ufcstats.com/fighter-details/c295de4e10acd4c9
+Joshua Van,"5' 5""",125 lbs.,"65""",Orthodox,"Oct 10, 2001",http://ufcstats.com/fighter-details/17e97649403ba428
 Mike van Arsdale,"6' 2""",205 lbs.,--,Switch,"Jun 20, 1965",http://ufcstats.com/fighter-details/2ee09ec2a0695eb9
 Matt Van Buren,"6' 5""",205 lbs.,--,,"Jun 12, 1986",http://ufcstats.com/fighter-details/7b39035fae7268b8
-Brianna Van Buren,"5' 0""",115 lbs.,"62""",Southpaw,"Aug 04, 1993",http://ufcstats.com/fighter-details/b53c46f613f6f248
 Ron van Clief,"5' 10""",190 lbs.,--,Orthodox,"Jan 25, 1943",http://ufcstats.com/fighter-details/23ab42947c1990e3
 Lloyd Van Dams,"6' 1""",240 lbs.,--,Southpaw,"Mar 05, 1972",http://ufcstats.com/fighter-details/02177caefe7c07d4
-Cameron VanCamp,"6' 2""",155 lbs.,--,Switch,"Apr 27, 1993",http://ufcstats.com/fighter-details/87e2468b986ebb79
+Alain Van der Merckt,--,185 lbs.,--,,"Jun 11, 1993",http://ufcstats.com/fighter-details/f6bbc6ba4f06ad60
+Cameron VanCamp,"6' 2""",155 lbs.,"74""",Switch,"Apr 27, 1993",http://ufcstats.com/fighter-details/87e2468b986ebb79
 Chad Vance,"6' 0""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/26d61e92a6069cd2
 Jared Vanderaa,"6' 4""",265 lbs.,"80""",Orthodox,"May 12, 1992",http://ufcstats.com/fighter-details/2b68d9f125d07b42
 Austin Vanderford,"5' 11""",170 lbs.,--,Orthodox,"Mar 21, 1990",http://ufcstats.com/fighter-details/32c3ee378671a5d9
@@ -3484,6 +3975,7 @@ Manny Vazquez,"5' 10""",125 lbs.,"72""",Orthodox,"Nov 19, 1993",http://ufcstats.
 Matt Veach,"5' 11""",155 lbs.,--,Orthodox,"May 31, 1981",http://ufcstats.com/fighter-details/5731cc327790b731
 Joe Vedepo,"6' 0""",185 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/d35c3ed553b71fa2
 Kelly Velasco,"5' 9""",135 lbs.,--,Orthodox,"May 21, 1995",http://ufcstats.com/fighter-details/93c9897f0f9f5dab
+Greg Velasco,"6' 2""",265 lbs.,"70""",Southpaw,"Sep 23, 1993",http://ufcstats.com/fighter-details/34a81ebbce32b06b
 Cain Velasquez,"6' 1""",240 lbs.,"77""",Orthodox,"Jul 28, 1982",http://ufcstats.com/fighter-details/0ff11cc094e887bc
 David Velasquez,"5' 5""",145 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/09c44b317c98bf96
 Bojan Velickovic,"6' 0""",170 lbs.,"76""",Southpaw,"Dec 18, 1988",http://ufcstats.com/fighter-details/fcce75a25c14a804
@@ -3494,18 +3986,21 @@ Scott Ventimiglia,"5' 11""",185 lbs.,--,,"Nov 17, 1972",http://ufcstats.com/figh
 Brandon Vera,"6' 3""",230 lbs.,"78""",Orthodox,"Oct 10, 1977",http://ufcstats.com/fighter-details/fa315e6c77eee106
 Kerry Vera,"5' 7""",135 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/df0a1c1e11ad199b
 Marlon Vera,"5' 8""",135 lbs.,"70""",Switch,"Dec 02, 1992",http://ufcstats.com/fighter-details/7c7332319c14094c
+Carlos Vera,"5' 6""",135 lbs.,"69""",Orthodox,"Nov 05, 1987",http://ufcstats.com/fighter-details/07f959e6596307bb
+Isis Verbeek,"5' 4""",115 lbs.,"64""",Orthodox,"Jan 12, 1995",http://ufcstats.com/fighter-details/d6f58b8cd1a6ff52
 Ernie Verdicia,"5' 11""",199 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/2b1587a3376ab743
 Joe Veres,"5' 7""",155 lbs.,--,Orthodox,"Nov 09, 1977",http://ufcstats.com/fighter-details/c6d8ae3b016d5ad5
-Nikolay Veretennikov,"6' 1""",170 lbs.,"74""",Orthodox,"Dec 22, 1989",http://ufcstats.com/fighter-details/0f1efce7d2571d10
-CJ Vergara,"5' 6""",135 lbs.,"68""",Orthodox,"Jun 18, 1991",http://ufcstats.com/fighter-details/077e3ace32b72be9
+Nikolay Veretennikov,"6' 1""",170 lbs.,"75""",Orthodox,"Dec 22, 1989",http://ufcstats.com/fighter-details/0f1efce7d2571d10
+CJ Vergara,"5' 6""",125 lbs.,"68""",Orthodox,"Jun 18, 1991",http://ufcstats.com/fighter-details/077e3ace32b72be9
 Renato Verissimo,"6' 1""",170 lbs.,--,Orthodox,"Aug 03, 1973",http://ufcstats.com/fighter-details/c24b1db4b809d41b
 Bryan Vetell,"6' 3""",265 lbs.,--,Southpaw,"Jul 26, 1977",http://ufcstats.com/fighter-details/13a0fb8fbdafb54f
-Marvin Vettori,"6' 0""",205 lbs.,"74""",Southpaw,"Sep 20, 1993",http://ufcstats.com/fighter-details/7acbb0972e75281a
+Marvin Vettori,"6' 0""",185 lbs.,"74""",Southpaw,"Sep 20, 1993",http://ufcstats.com/fighter-details/7acbb0972e75281a
 Hugo Viana,"5' 6""",135 lbs.,"67""",Orthodox,"Sep 26, 1982",http://ufcstats.com/fighter-details/f95381efb3051d81
 Guilherme Viana,"6' 4""",205 lbs.,--,,--,http://ufcstats.com/fighter-details/393b8e03fb410a78
 Polyana Viana,"5' 5""",115 lbs.,"67""",Orthodox,"Jun 14, 1992",http://ufcstats.com/fighter-details/9673a497a9da119a
 Vitor Vianna,--,205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/744f50016c39c26c
 James Vick,"6' 3""",155 lbs.,"76""",Orthodox,"Feb 23, 1987",http://ufcstats.com/fighter-details/6256b2b1562cb8e1
+Tamires Vidal,"5' 6""",135 lbs.,"68""",Orthodox,"Jul 27, 1998",http://ufcstats.com/fighter-details/4f3064faf17aa711
 Milton Vieira,"6' 0""",145 lbs.,--,Orthodox,"Oct 04, 1978",http://ufcstats.com/fighter-details/7cf20446453f852b
 Reginaldo Vieira,"5' 7""",135 lbs.,"65""",Orthodox,"Nov 26, 1982",http://ufcstats.com/fighter-details/f9081770e28ea2e1
 Ketlen Vieira,"5' 8""",135 lbs.,"68""",Orthodox,"Aug 26, 1991",http://ufcstats.com/fighter-details/b9706f80d005036c
@@ -3526,6 +4021,8 @@ Brandon Visher,"5' 6""",135 lbs.,"68""",Orthodox,"May 06, 1984",http://ufcstats.
 Falaniko Vitale,"5' 10""",185 lbs.,--,Orthodox,"Jul 14, 1974",http://ufcstats.com/fighter-details/445a98acb8985970
 Cheyanne Vlismas,"5' 3""",115 lbs.,"63""",Switch,"Jun 25, 1995",http://ufcstats.com/fighter-details/4959f10a62f3fec3
 Bobby Voelker,"6' 0""",170 lbs.,"74""",Orthodox,"Apr 26, 1979",http://ufcstats.com/fighter-details/fb8a3025ae722e64
+Mateo Vogel,"5' 8""",145 lbs.,"71""",Orthodox,"Mar 05, 1996",http://ufcstats.com/fighter-details/90b57b19d20e1969
+Danylo Voievodkin,"6' 4""",265 lbs.,"78""",Southpaw,"Jul 19, 2000",http://ufcstats.com/fighter-details/d73a7c36746fbc5b
 Alexander Volkanovski,"5' 6""",145 lbs.,"71""",Orthodox,"Sep 29, 1988",http://ufcstats.com/fighter-details/e1248941344b3288
 Jacob Volkmann,"5' 9""",155 lbs.,"71""",Southpaw,"Sep 05, 1980",http://ufcstats.com/fighter-details/6f81b6de2557739a
 Alexander Volkov,"6' 7""",250 lbs.,"80""",Orthodox,"Oct 24, 1988",http://ufcstats.com/fighter-details/279566840aa55bf2
@@ -3533,6 +4030,7 @@ Jason Von Flue,"6' 0""",170 lbs.,--,Orthodox,"Aug 01, 1975",http://ufcstats.com/
 Milco Voorn,--,220 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/277ffed20cf07aea
 Mark Vorgeas,"5' 10""",135 lbs.,--,,--,http://ufcstats.com/fighter-details/ef0344ed552d8a22
 Igor Vovchanchyn,"5' 8""",205 lbs.,--,Orthodox,"Aug 06, 1973",http://ufcstats.com/fighter-details/7929be8290289a47
+Jordan Vucenic,"5' 10""",155 lbs.,"73""",Orthodox,"Mar 02, 1996",http://ufcstats.com/fighter-details/6d38e41efa47a72d
 James Wade,"5' 10""",205 lbs.,--,,--,http://ufcstats.com/fighter-details/6291decf7f3b6608
 Chris Wade,"5' 10""",155 lbs.,"70""",Orthodox,"Sep 30, 1987",http://ufcstats.com/fighter-details/c8097968da5e5f13
 Neil Wain,"5' 10""",242 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/6b7bc7eaf2465387
@@ -3542,6 +4040,8 @@ Andre Walker,"5' 11""",205 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-detai
 Herschel Walker,"6' 1""",215 lbs.,--,Orthodox,"Mar 03, 1962",http://ufcstats.com/fighter-details/bd92e38aef641673
 Donny Walker,"5' 9""",135 lbs.,--,,"Jan 04, 1980",http://ufcstats.com/fighter-details/e6147d5ab3685899
 Johnny Walker,"6' 6""",205 lbs.,"82""",Orthodox,"Mar 30, 1992",http://ufcstats.com/fighter-details/c21f26bbde777573
+Brogan Walker,"5' 4""",125 lbs.,"67""",Switch,"Aug 02, 1988",http://ufcstats.com/fighter-details/4333a8e70a672eb7
+Valter Walker,"6' 6""",265 lbs.,"78""",Orthodox,"Dec 14, 1997",http://ufcstats.com/fighter-details/f5779a2303ed76ec
 Ben Wall,"5' 10""",155 lbs.,--,Orthodox,"Mar 25, 1989",http://ufcstats.com/fighter-details/1ad381c8994c4e5b
 Crafton Wallace,"6' 0""",185 lbs.,--,Orthodox,"Nov 10, 1975",http://ufcstats.com/fighter-details/bf41b5131545da12
 Rodney Wallace,"5' 9""",205 lbs.,"72""",Switch,"Nov 21, 1981",http://ufcstats.com/fighter-details/b9415726dc3ec526
@@ -3557,6 +4057,8 @@ Dimitiri Wanderley,--,205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-detail
 Andy Wang,"5' 6""",155 lbs.,--,Orthodox,"May 28, 1977",http://ufcstats.com/fighter-details/476414d2f18cd059
 Sai Wang,"6' 0""",170 lbs.,--,Southpaw,"Jan 14, 1986",http://ufcstats.com/fighter-details/efb9a43415a56d34
 Anying Wang,"6' 0""",170 lbs.,--,Orthodox,"Apr 04, 1991",http://ufcstats.com/fighter-details/69e8c632135af48b
+Wang Cong,"5' 6""",125 lbs.,"66""",Southpaw,"May 15, 1992",http://ufcstats.com/fighter-details/2997e7fe3c9d3d4a
+Joshua Wang-Kim,"5' 9""",135 lbs.,"71""",Switch,"Nov 16, 1992",http://ufcstats.com/fighter-details/d538f13ab21d9633
 Curt Warburton,"6' 0""",155 lbs.,"73""",Orthodox,--,http://ufcstats.com/fighter-details/2721bb808bb2523c
 Brennan Ward,"5' 10""",170 lbs.,"71""",,"Jun 28, 1988",http://ufcstats.com/fighter-details/67cd6495280b0a57
 Charlie Ward,"5' 11""",170 lbs.,--,Orthodox,"Dec 17, 1980",http://ufcstats.com/fighter-details/e81dd0bb8a64b550
@@ -3570,7 +4072,8 @@ Kazuhisa Watanabe,"5' 6""",139 lbs.,--,,"May 18, 1983",http://ufcstats.com/fight
 Ron Waterman,"6' 2""",280 lbs.,--,Orthodox,"Nov 23, 1965",http://ufcstats.com/fighter-details/efaf544314bb5c2e
 Andy Waters,"6' 0""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/103e2e67919379c5
 Dominic Waters,"6' 1""",170 lbs.,"79""",Orthodox,"Apr 11, 1989",http://ufcstats.com/fighter-details/2de91c2244ad7e89
-Michelle Waterson,"5' 3""",115 lbs.,"62""",Orthodox,"Jan 06, 1986",http://ufcstats.com/fighter-details/eb04b9d31e938edb
+Trey Waters,"6' 5""",170 lbs.,"77""",Orthodox,"Feb 21, 1995",http://ufcstats.com/fighter-details/31dbfbe4e7a6727c
+Michelle Waterson-Gomez,"5' 3""",115 lbs.,"62""",Orthodox,"Jan 06, 1986",http://ufcstats.com/fighter-details/eb04b9d31e938edb
 Sam Watford,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/1836639ecf9b6e7f
 Blake Watkins,--,185 lbs.,--,,--,http://ufcstats.com/fighter-details/117580b232409824
 Kyle Watson,"6' 0""",155 lbs.,--,Southpaw,"Aug 09, 1979",http://ufcstats.com/fighter-details/d7b2c0b53883ee80
@@ -3588,6 +4091,7 @@ Daniel Weichel,"5' 10""",145 lbs.,"70""",,"Nov 22, 1984",http://ufcstats.com/fig
 Chris Weidman,"6' 2""",185 lbs.,"78""",Orthodox,"Jun 17, 1984",http://ufcstats.com/fighter-details/3a8176e15b9887c1
 Mark Weir,"6' 2""",185 lbs.,--,Southpaw,"Sep 19, 1967",http://ufcstats.com/fighter-details/9ccdd2ce45903f34
 Christian Wellisch,"6' 2""",234 lbs.,"77""",Orthodox,"Sep 13, 1975",http://ufcstats.com/fighter-details/f1b2a4365799c48b
+Malcolm Wellmaker,"5' 10""",135 lbs.,"71""",Switch,"Jun 04, 1994",http://ufcstats.com/fighter-details/2e45d08b3f2f02c8
 Jeremiah Wells,"5' 9""",170 lbs.,"74""",Switch,"Oct 30, 1986",http://ufcstats.com/fighter-details/d66a46de8d705353
 Fabricio Werdum,"6' 4""",231 lbs.,"77""",Orthodox,"Jul 30, 1977",http://ufcstats.com/fighter-details/492b202d2064e7a9
 Mike Wessel,"6' 0""",260 lbs.,--,Orthodox,"Dec 02, 1977",http://ufcstats.com/fighter-details/b51841e7c594090d
@@ -3606,12 +4110,13 @@ Garett Whiteley,"6' 0""",155 lbs.,"72""",Orthodox,"Dec 13, 1980",http://ufcstats
 Mitch Whitesel,"5' 9""",185 lbs.,--,,"Jul 12, 1981",http://ufcstats.com/fighter-details/b6debbda44d4a5a0
 Emily Whitmire,"5' 5""",125 lbs.,"63""",Orthodox,"May 24, 1991",http://ufcstats.com/fighter-details/b3d21b2610dcfaeb
 Robert Whittaker,"6' 0""",185 lbs.,"73""",Orthodox,"Dec 20, 1990",http://ufcstats.com/fighter-details/e1147d3d2dabe1ce
+Josh Wick,"5' 9""",155 lbs.,"69""",Switch,"Oct 04, 1994",http://ufcstats.com/fighter-details/13935768cf8aeb86
 Adam Wieczorek,"6' 5""",250 lbs.,"81""",Orthodox,"Feb 05, 1992",http://ufcstats.com/fighter-details/efa1f6b42c86793c
 Orlando Wiet,"5' 10""",170 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/a6c2f5381d575920
 Jonathan Wiezorek,"6' 3""",250 lbs.,--,Southpaw,"Feb 10, 1978",http://ufcstats.com/fighter-details/60884f31ead1609c
 Justin Wilcox,"5' 6""",155 lbs.,--,Orthodox,"Mar 12, 1979",http://ufcstats.com/fighter-details/4a482a0100cfcd0a
 Joe Wilk,"5' 9""",145 lbs.,--,,"Apr 12, 1982",http://ufcstats.com/fighter-details/781014fb7e8e647a
-Aaron Wilkinson,"5' 10""",155 lbs.,--,,"Jan 31, 1987",http://ufcstats.com/fighter-details/338a11d3674eb2d4
+Aaron Wilkinson,"5' 10""",155 lbs.,--,Orthodox,"Jan 31, 1987",http://ufcstats.com/fighter-details/338a11d3674eb2d4
 Mike Wilkinson,"5' 7""",145 lbs.,"66""",Orthodox,"Sep 15, 1987",http://ufcstats.com/fighter-details/cfaf010d5b389c09
 Rob Wilkinson,"6' 3""",185 lbs.,"80""",Orthodox,"Feb 22, 1992",http://ufcstats.com/fighter-details/826475cc758e60e6
 James Wilks,"6' 1""",170 lbs.,"75""",Orthodox,"May 04, 1978",http://ufcstats.com/fighter-details/852454c572675334
@@ -3624,12 +4129,14 @@ Tim Williams,"6' 2""",185 lbs.,"76""",Orthodox,"Jul 03, 1986",http://ufcstats.co
 Jordan Williams,"6' 1""",185 lbs.,"75""",Southpaw,"Oct 13, 1990",http://ufcstats.com/fighter-details/e26bd53b751d61d9
 Cole Williams,"6' 0""",170 lbs.,"73""",Orthodox,"Dec 15, 1983",http://ufcstats.com/fighter-details/f9a20a17d712ef7c
 Khaos Williams,"6' 0""",170 lbs.,"77""",Orthodox,"Mar 30, 1994",http://ufcstats.com/fighter-details/2558ae2e5671e318
+Karl Williams,"6' 3""",235 lbs.,"79""",Orthodox,"Jan 06, 1990",http://ufcstats.com/fighter-details/d35f734c56a89103
 Karl Willis,--,--,--,,--,http://ufcstats.com/fighter-details/95883dbdab4fcf0f
 Justin Willis,"6' 1""",264 lbs.,"78""",Southpaw,"Jul 19, 1987",http://ufcstats.com/fighter-details/ce1e867808ef5fce
 Chris Wilson,"6' 1""",170 lbs.,"75""",Orthodox,"Jun 07, 1977",http://ufcstats.com/fighter-details/a56607a451e4c70d
 Greg Wilson,--,155 lbs.,--,,"Oct 02, 1988",http://ufcstats.com/fighter-details/9cc84087ee768342
 Jonathan Wilson,"6' 2""",205 lbs.,"75""",Southpaw,"Jul 17, 1987",http://ufcstats.com/fighter-details/cd01f0b768a32475
 Sean Wilson,"5' 8""",145 lbs.,--,,"Oct 20, 1982",http://ufcstats.com/fighter-details/b8e6393c39cb9740
+Westin Wilson,"6' 1""",145 lbs.,"73""",Southpaw,"Jan 24, 1989",http://ufcstats.com/fighter-details/7b3503352cd53abb
 Matt Wiman,"5' 10""",155 lbs.,"68""",Orthodox,"Sep 19, 1983",http://ufcstats.com/fighter-details/eb29176b03dfa888
 Eddie Wineland,"5' 7""",135 lbs.,"69""",Orthodox,"Jun 26, 1984",http://ufcstats.com/fighter-details/fc9a9559a05f2704
 Deron Winn,"5' 6""",185 lbs.,"70""",Orthodox,"Jun 13, 1989",http://ufcstats.com/fighter-details/483a953b18d73bb3
@@ -3639,13 +4146,16 @@ Keith Wisniewski,"6' 0""",170 lbs.,--,Orthodox,"Oct 25, 1981",http://ufcstats.co
 Jason Witt,"5' 10""",170 lbs.,"70""",Orthodox,"Nov 07, 1986",http://ufcstats.com/fighter-details/5f3805dda9661cba
 Travis Wiuff,"6' 3""",205 lbs.,--,Orthodox,"Mar 15, 1978",http://ufcstats.com/fighter-details/7f9f528cb72a6ed1
 Ray Wizard,--,--,--,,--,http://ufcstats.com/fighter-details/ea0ad155451ed1f5
+Karolina Wojcik,"5' 2""",115 lbs.,--,Orthodox,"Dec 09, 1994",http://ufcstats.com/fighter-details/b99b3620839ea911
 Danyelle Wolf,"5' 11""",145 lbs.,"70""",Orthodox,"Sep 08, 1983",http://ufcstats.com/fighter-details/a7e3f02fe2b2fe30
 Brandon Wolff,"5' 9""",170 lbs.,--,Orthodox,"Oct 18, 1975",http://ufcstats.com/fighter-details/aa79d5399571068e
 Xue Do Won,"5' 7""",165 lbs.,--,,--,http://ufcstats.com/fighter-details/daa89f01e1c0f42a
 Joanne Wood,"5' 6""",125 lbs.,"65""",Orthodox,"Dec 23, 1985",http://ufcstats.com/fighter-details/12f91bfa8f1f723b
-Nathaniel Wood,"5' 6""",135 lbs.,"69""",Orthodox,"May 08, 1993",http://ufcstats.com/fighter-details/329e403448756217
+Nathaniel Wood,"5' 6""",145 lbs.,"69""",Orthodox,"May 08, 1993",http://ufcstats.com/fighter-details/329e403448756217
+Val Woodburn,"5' 8""",170 lbs.,"74""",Orthodox,"Aug 10, 1993",http://ufcstats.com/fighter-details/7a47e068f8017019
 Tyron Woodley,"5' 9""",170 lbs.,"74""",Orthodox,"Apr 07, 1982",http://ufcstats.com/fighter-details/effd9de9937996f8
 Salvador Woods,"5' 11""",170 lbs.,--,,"Feb 05, 1985",http://ufcstats.com/fighter-details/8de471543d9c933e
+Logan Woods,--,185 lbs.,--,,"May 30, 1994",http://ufcstats.com/fighter-details/133a9d2e6efd8a50
 Sean Woodson,"6' 2""",145 lbs.,"78""",Orthodox,"Jun 07, 1992",http://ufcstats.com/fighter-details/4682bc59d5f55145
 Cal Worsham,"5' 11""",230 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/de3ed2e152520c8d
 Hunter Worsham,--,185 lbs.,--,,--,http://ufcstats.com/fighter-details/8fb808fc2e145bd6
@@ -3654,15 +4164,18 @@ Eric Wray,"6' 0""",170 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/e
 Justin Wren,"6' 2""",265 lbs.,--,Orthodox,"Apr 27, 1987",http://ufcstats.com/fighter-details/e78f601035d677f2
 JW Wright,--,130 lbs.,--,,"Jan 12, 1976",http://ufcstats.com/fighter-details/2a0b19a96f848eff
 Chris Wright,--,--,--,,--,http://ufcstats.com/fighter-details/7182146226dabe22
-Jordan Wright,"6' 2""",185 lbs.,"77""",Orthodox,"Oct 07, 1991",http://ufcstats.com/fighter-details/c878270af633eb11
+Jordan Wright,"6' 2""",205 lbs.,"77""",Orthodox,"Oct 07, 1991",http://ufcstats.com/fighter-details/c878270af633eb11
 Marcin Wrzosek,"5' 9""",155 lbs.,--,,"Oct 14, 1987",http://ufcstats.com/fighter-details/aac6edb0d5e0b7e9
 Wu Yanan,"5' 8""",135 lbs.,"66""",Orthodox,"Apr 18, 1996",http://ufcstats.com/fighter-details/fdbefee0827e1567
+Wulijiburen,"5' 9""",135 lbs.,"69""",Orthodox,"Mar 01, 1989",http://ufcstats.com/fighter-details/2296125b6c362355
+Wuziazibieke Jiahefu,"5' 9""",145 lbs.,"70""",Orthodox,"Apr 09, 1990",http://ufcstats.com/fighter-details/2d077e22886298be
 Rubens Xavier,"6' 3""",220 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/e6dac752a2418a88
-Xiao Long,"5' 8""",135 lbs.,"66""",Orthodox,"Apr 13, 1998",http://ufcstats.com/fighter-details/86bace9e4ad85542
-Xie Bin,"5' 10""",145 lbs.,"72""",Orthodox,"Feb 28, 1998",http://ufcstats.com/fighter-details/e415ea6f8d41c917
+Xiao Long,"5' 8""",135 lbs.,"70""",Orthodox,"Apr 13, 1998",http://ufcstats.com/fighter-details/86bace9e4ad85542
+Xie Bin,"5' 9""",145 lbs.,"71""",Orthodox,"Feb 28, 1998",http://ufcstats.com/fighter-details/e415ea6f8d41c917
 Jamie Yager,"6' 1""",185 lbs.,--,Orthodox,"Nov 29, 1983",http://ufcstats.com/fighter-details/85248da6e9e2f7e7
 Eddie Yagin,"5' 7""",145 lbs.,--,Orthodox,"Mar 23, 1979",http://ufcstats.com/fighter-details/cc84b68f862b466f
 Rani Yahya,"5' 6""",135 lbs.,"67""",Orthodox,"Sep 12, 1984",http://ufcstats.com/fighter-details/94527830000ab715
+Mohammad Yahya,"5' 9""",155 lbs.,"73""",Switch,"May 23, 1994",http://ufcstats.com/fighter-details/3753714927f18437
 Alexander Yakovlev,"6' 3""",155 lbs.,"74""",Southpaw,"Jul 18, 1984",http://ufcstats.com/fighter-details/d06f8869449ba7bd
 Keiichiro Yamamiya,"5' 11""",185 lbs.,--,Southpaw,"Jul 12, 1972",http://ufcstats.com/fighter-details/6014d25e73b669c9
 Kenichi Yamamoto,"6' 0""",170 lbs.,--,Orthodox,"Jul 11, 1976",http://ufcstats.com/fighter-details/9f488f520ed25bbf
@@ -3674,7 +4187,7 @@ Goiti Yamauchi,"5' 10""",145 lbs.,--,,"Jan 05, 1993",http://ufcstats.com/fighter
 Takeshi Yamazaki,"5' 8""",139 lbs.,--,Southpaw,--,http://ufcstats.com/fighter-details/d1d20e651e6cbc02
 Yan Xiaonan,"5' 5""",115 lbs.,"63""",Orthodox,"Jun 16, 1989",http://ufcstats.com/fighter-details/c41d426cc7326d1b
 Petr Yan,"5' 7""",135 lbs.,"67""",Switch,"Feb 11, 1993",http://ufcstats.com/fighter-details/d661ce4da776fc20
-Yan Qihui,"5' 3""",125 lbs.,"62""",Orthodox,"Oct 01, 1996",http://ufcstats.com/fighter-details/5c9c2e247c836b67
+Yan Qihui,"5' 3""",125 lbs.,"62""",Orthodox,"Oct 21, 1996",http://ufcstats.com/fighter-details/5c9c2e247c836b67
 Adam Yandiev,"5' 9""",185 lbs.,"74""",Orthodox,"Aug 07, 1988",http://ufcstats.com/fighter-details/0a95c474e61a6c44
 Adrian Yanez,"5' 7""",135 lbs.,"70""",Orthodox,"Nov 29, 1993",http://ufcstats.com/fighter-details/0232cabbc30a2372
 Dongi Yang,"5' 10""",185 lbs.,"73""",Southpaw,"Dec 07, 1984",http://ufcstats.com/fighter-details/aed06011bf62237b
@@ -3685,20 +4198,25 @@ Cale Yarbrough,"6' 1""",185 lbs.,--,Orthodox,"Dec 27, 1986",http://ufcstats.com/
 Tadao Yasuda,"6' 4""",310 lbs.,--,Orthodox,"Oct 09, 1963",http://ufcstats.com/fighter-details/49e7e05f902479ca
 Yoshiaki Yatsu,"6' 1""",165 lbs.,--,Orthodox,"Jul 19, 1956",http://ufcstats.com/fighter-details/620be7e0712d431b
 Chris Yee,"5' 9""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/920632ca1b78fae5
+Yibugele,"5' 7""",145 lbs.,"69""",Southpaw,"Nov 13, 1989",http://ufcstats.com/fighter-details/cc2fcae2c0dc501d
+Yin Shuai,"5' 7""",125 lbs.,"65""",Southpaw,"Jan 01, 1997",http://ufcstats.com/fighter-details/a78dc3910554dbae
+Yizha,"5' 7""",145 lbs.,"71""",Orthodox,"Jan 08, 1997",http://ufcstats.com/fighter-details/3f11fd1751fa83b1
 Ashley Yoder,"5' 7""",115 lbs.,"69""",Southpaw,"Oct 20, 1987",http://ufcstats.com/fighter-details/b4c6c904a9ffc5e8
 Hirotaka Yokoi,"5' 11""",205 lbs.,--,Orthodox,"Jun 08, 1978",http://ufcstats.com/fighter-details/35585d970300d45a
 Kazunori Yokota,"5' 8""",154 lbs.,--,Orthodox,"Apr 03, 1978",http://ufcstats.com/fighter-details/a8e8587a06e73c87
 John Yoo,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/40eb2aef4d5577d4
-Sanghoon Yoo,"6' 0""",155 lbs.,"74""",Orthodox,"Jan 18, 1990",http://ufcstats.com/fighter-details/00b490982afd1b17
+SangHoon Yoo,"6' 0""",170 lbs.,"74""",Orthodox,"Jan 18, 1990",http://ufcstats.com/fighter-details/00b490982afd1b17
 Dong Sik Yoon,"6' 0""",185 lbs.,--,Orthodox,"Aug 24, 1972",http://ufcstats.com/fighter-details/ad99fa5325519169
 Yoshiyuki Yoshida,"5' 11""",170 lbs.,"70""",Southpaw,"May 10, 1974",http://ufcstats.com/fighter-details/ab8900ae1f1dfd4c
 Hidehiko Yoshida,"5' 11""",225 lbs.,--,Orthodox,"Sep 03, 1969",http://ufcstats.com/fighter-details/2eae41f61776c60f
+SuYoung You,"5' 6""",135 lbs.,"65""",Orthodox,"Dec 11, 1995",http://ufcstats.com/fighter-details/a474aade8eb3a8f0
 Kaitlin Young,"5' 9""",135 lbs.,--,Orthodox,"Sep 15, 1985",http://ufcstats.com/fighter-details/79ff6545b0abc685
 Artenus Young,--,205 lbs.,--,,"Jul 16, 1980",http://ufcstats.com/fighter-details/8d4943a9ce9f521b
 Trenell Young,"5' 6""",145 lbs.,--,Orthodox,"Jun 19, 1976",http://ufcstats.com/fighter-details/bf5183e1c1afc3b2
 Jason Young,"5' 9""",145 lbs.,"73""",Orthodox,"Jun 28, 1986",http://ufcstats.com/fighter-details/f59e9e49ef85b469
 Shane Young,"5' 8""",145 lbs.,"72""",Orthodox,"Jul 31, 1993",http://ufcstats.com/fighter-details/4cd8b03aee1d0138
-Shanna Young,"5' 7""",135 lbs.,"65""",Orthodox,"Feb 20, 1991",http://ufcstats.com/fighter-details/568bbad0eaced57c
+Shanna Young,"5' 7""",125 lbs.,"65""",Orthodox,"Feb 20, 1991",http://ufcstats.com/fighter-details/568bbad0eaced57c
+Gauge Young,"5' 9""",155 lbs.,"70""",Orthodox,"Jul 14, 2000",http://ufcstats.com/fighter-details/b2a78df161bd67f9
 Besam Yousef,"5' 11""",170 lbs.,--,Orthodox,"Mar 25, 1985",http://ufcstats.com/fighter-details/98ec9f385cca47fc
 Han Ten Yun,"5' 11""",220 lbs.,--,,--,http://ufcstats.com/fighter-details/67ec58d7cf599835
 Rob Yundt,"6' 1""",185 lbs.,--,Orthodox,"May 05, 1980",http://ufcstats.com/fighter-details/42078a86d3dd037b
@@ -3714,16 +4232,21 @@ Zach Zane,"5' 7""",145 lbs.,"69""",Southpaw,"Dec 14, 1989",http://ufcstats.com/f
 Roger Zapata,"5' 11""",170 lbs.,--,Southpaw,"May 09, 1986",http://ufcstats.com/fighter-details/fe5ca7ef93c3f6a7
 Marius Zaromskis,"5' 9""",170 lbs.,--,Orthodox,"Jul 30, 1980",http://ufcstats.com/fighter-details/abcf7e55a0a9ed89
 David Zawada,"6' 0""",170 lbs.,"75""",Orthodox,"Aug 01, 1990",http://ufcstats.com/fighter-details/3bb2dc8e87b10a46
+Manolo Zecchini,"5' 8""",145 lbs.,"68""",Orthodox,"Oct 22, 1996",http://ufcstats.com/fighter-details/fd7ab338e4953644
 Joao Zeferino,"5' 11""",170 lbs.,--,Orthodox,"Jan 15, 1986",http://ufcstats.com/fighter-details/be4076c9e8d791e3
 Daniel Zellhuber,"6' 1""",155 lbs.,"77""",Switch,"Jul 07, 1999",http://ufcstats.com/fighter-details/4148802ae4a50768
 Craig Zellner,"6' 2""",205 lbs.,--,Orthodox,"Sep 09, 1976",http://ufcstats.com/fighter-details/3794e5e0bb0defb6
+Rickson Zenidim,"5' 7""",125 lbs.,"67""",Orthodox,"Feb 17, 1999",http://ufcstats.com/fighter-details/c879d8620261b1a3
 Roman Zentsov,"6' 1""",230 lbs.,--,Orthodox,"Sep 10, 1973",http://ufcstats.com/fighter-details/3144121470023e9a
 Carlos Zevallos,"6' 0""",205 lbs.,--,Orthodox,--,http://ufcstats.com/fighter-details/cbf69fa846c7e3ee
 Zhang Tiequan,"5' 8""",155 lbs.,"69""",Orthodox,"Jul 25, 1978",http://ufcstats.com/fighter-details/c23e3d4875340d8d
 Zhang Lipeng,"5' 11""",155 lbs.,"71""",Southpaw,"Mar 10, 1990",http://ufcstats.com/fighter-details/7b310409440c9102
 Zhang Weili,"5' 4""",115 lbs.,"63""",Switch,"Aug 13, 1989",http://ufcstats.com/fighter-details/1ebe20ebbfa15e29
-Zhang Minyang,--,--,--,,--,http://ufcstats.com/fighter-details/8a65fd9ba31fd3f7
+Zhang Mingyang,"6' 2""",205 lbs.,"75""",Orthodox,"Aug 16, 1998",http://ufcstats.com/fighter-details/8a65fd9ba31fd3f7
+Daermisi Zhawupasi,"5' 8""",135 lbs.,"68""",Switch,"Sep 15, 1999",http://ufcstats.com/fighter-details/fd52e5f9ab25c94c
+Daria Zhelezniakova,"5' 9""",135 lbs.,"68""",Orthodox,"Jan 23, 1996",http://ufcstats.com/fighter-details/07047eb7d17fb0a2
 Yao Zhikui,"5' 5""",125 lbs.,"64""",Orthodox,"Feb 07, 1991",http://ufcstats.com/fighter-details/5ea918ea81b7dee2
+Zhu Kangjie,"5' 6""",145 lbs.,"70""",Orthodox,"Jan 16, 1996",http://ufcstats.com/fighter-details/6f4ec5aa3eced219
 Zhalgas Zhumagulov,"5' 4""",125 lbs.,"66""",Switch,"Aug 29, 1988",http://ufcstats.com/fighter-details/55fa6ce3e522c8bb
 Fares Ziam,"6' 1""",155 lbs.,"75""",Orthodox,"Mar 21, 1997",http://ufcstats.com/fighter-details/1e4f273069fb9e85
 Mike Zichelle,--,205 lbs.,--,,--,http://ufcstats.com/fighter-details/6d3398b910461f2f
@@ -3736,531 +4259,3 @@ Alex Zuniga,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/02d808afb9666
 George Zuniga,"5' 9""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/1291dd6b8ab4d952
 Allan Zuniga,"5' 7""",155 lbs.,"70""",Orthodox,"Apr 04, 1992",http://ufcstats.com/fighter-details/523af801b3429015
 Virgil Zwicker,"6' 2""",205 lbs.,"74""",,"Jun 26, 1982",http://ufcstats.com/fighter-details/0c277f3ff66b0208
-Tatsuro Taira,--,--,--,,"Jan 27, 2000",http://ufcstats.com/fighter-details/4461d7e47375a895
-Trey Ogden,--,155 lbs.,--,,"Nov 14, 1989",http://ufcstats.com/fighter-details/cfc3e7bb44685289
-Josh Fremd,"6' 4""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/ca43de99b07b6b40
-Ramona Pascual,--,135 lbs.,--,,"Sep 23, 1988",http://ufcstats.com/fighter-details/3eb4dc9a7d4ac906
-Denis Tiuliulin,--,185 lbs.,--,,"May 17, 1988",http://ufcstats.com/fighter-details/0112352cb32f5026
-Daniel Lacerda,--,125 lbs.,--,Switch,"Jun 05, 1996",http://ufcstats.com/fighter-details/b5681522d7d6b122
-Evan Elder,"5' 9""",155 lbs.,--,,"Apr 11, 1997",http://ufcstats.com/fighter-details/d9a56ecb6e94f02e
-Charles Johnson,--,125 lbs.,--,,"Jan 10, 1991",http://ufcstats.com/fighter-details/814e5233e2acf2ee
-John Adajar,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/989b85f6540c86b1
-Angga,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/d6a3e131ad4ba064
-Balajin,--,155 lbs.,--,,"Mar 31, 1992",http://ufcstats.com/fighter-details/e626e92a8f2a9737
-SeungGuk Choi,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/adccbc19b22e19af
-Wallen Del Rosario,--,125 lbs.,--,,"Mar 18, 1993",http://ufcstats.com/fighter-details/a62f85f6a6c19a4c
-Shaun Etchell,--,125 lbs.,--,,"Aug 05, 1993",http://ufcstats.com/fighter-details/ea9bfe9c25037bba
-Gugun Gusman,--,135 lbs.,--,,"Mar 03, 1990",http://ufcstats.com/fighter-details/e34e3b1fffa13a6a
-JunYoung Hong,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/b24666e26bd750a3
-Yuma Horiuchi,--,125 lbs.,--,,"Sep 22, 1997",http://ufcstats.com/fighter-details/f6c1ce7cfd600662
-Yazmin Jauregui,"5' 3""",115 lbs.,--,,"Feb 28, 1999",http://ufcstats.com/fighter-details/40cb680ae1cd331f
-Asikeerbai Jinensibieke,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/4eccb78d628b2238
-Anshul Jubli,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/a72a2a769fa5a2be
-Toshiomi Kazama,--,135 lbs.,--,,"May 15, 1997",http://ufcstats.com/fighter-details/148bb103cfbf123e
-Maimaitituoheti Keremuaili,--,135 lbs.,--,,"Mar 18, 1991",http://ufcstats.com/fighter-details/772022b989534f0d
-WonBin Ki,--,155 lbs.,--,,"Feb 11, 1991",http://ufcstats.com/fighter-details/aaeb55084b198a39
-MinWoo Kim,--,135 lbs.,--,,"Jul 21, 1993",http://ufcstats.com/fighter-details/6343a95f1d9e6a33
-HanSeul Kim,--,170 lbs.,--,,"Jun 19, 1990",http://ufcstats.com/fighter-details/2bc47c7cc6c05bd7
-Kyung Pyo Kim,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/5a9f7b5ffebdd6e7
-Top Kiwram,--,125 lbs.,--,,"Aug 15, 1992",http://ufcstats.com/fighter-details/e065b4a42a6c2c79
-Josefine Knutsson,--,115 lbs.,--,,--,http://ufcstats.com/fighter-details/971dba22c622af12
-JeongYeong Lee,--,145 lbs.,--,,"Nov 13, 1995",http://ufcstats.com/fighter-details/d008d785f6347dc2
-Lu Kai,--,145 lbs.,--,,"Mar 01, 1994",http://ufcstats.com/fighter-details/a2d23e684b3db732
-Koyomi Matsushima,--,145 lbs.,--,,"Oct 08, 1992",http://ufcstats.com/fighter-details/5ad226da6c74a48e
-Ailiya Muratbek,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/9b6dcc335ad03696
-Rinya Nakamura,--,135 lbs.,--,,"Mar 23, 1995",http://ufcstats.com/fighter-details/d8c811df0386d5e8
-Shohei Nose,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/6b0e83b094f816ac
-HyunSung Park,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/b671bdf981ad527d
-Keisuke Sasu,--,145 lbs.,--,,"Sep 30, 1994",http://ufcstats.com/fighter-details/b7bcf6dfbbb7c16c
-YeDam Seo,--,115 lbs.,--,,"Mar 20, 1992",http://ufcstats.com/fighter-details/762572d67204fadb
-Pawan Maan Singh,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/450bacdacd706bcd
-Jeremia Siregar,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/a7ac3b1b0c4146db
-Rama Supandhi,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/6d537248fe7cccf1
-Tuco Tokkos,--,205 lbs.,--,,--,http://ufcstats.com/fighter-details/3e8118c1ab52f211
-Takeru Uchida,--,125 lbs.,--,,"Sep 30, 2002",http://ufcstats.com/fighter-details/1d76f07ffdd765c2
-Sho Usami,--,155 lbs.,--,,"May 08, 2000",http://ufcstats.com/fighter-details/fe30c5f5cc3e028b
-Yi Zha,--,145 lbs.,--,,"Jan 08, 1997",http://ufcstats.com/fighter-details/3f11fd1751fa83b1
-Tatsuya Ando,--,135 lbs.,--,,"Apr 26, 1990",http://ufcstats.com/fighter-details/17615148dd4be6f6
-Juan Andres Luna,--,125 lbs.,--,,"Aug 20, 1995",http://ufcstats.com/fighter-details/1fd9f744105024a8
-Farid Basharat,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/a09ed60aa67a3f67
-Anvar Boynazarov,--,145 lbs.,--,,"Jan 10, 1989",http://ufcstats.com/fighter-details/4a191f4ea2fce7fc
-Charlie Campbell,--,155 lbs.,--,,"Jul 03, 1995",http://ufcstats.com/fighter-details/b39f7a6c2be17ee8
-Clayton Carpenter,--,125 lbs.,--,,"Jun 04, 1996",http://ufcstats.com/fighter-details/b62d5280966b2460
-Jack Cartwright,--,135 lbs.,--,,"May 26, 1994",http://ufcstats.com/fighter-details/1f592bfefb0d62a3
-Alessandro Costa,--,125 lbs.,--,,"Jan 28, 1996",http://ufcstats.com/fighter-details/3fa97913cfd205d3
-Hailey Cowan,--,135 lbs.,--,,"Feb 12, 1992",http://ufcstats.com/fighter-details/3c26c420584d912d
-Emilio Cuellar,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/3aeb69b4a13ff0e8
-Acacio Dos Santos,--,205 lbs.,--,,"Sep 29, 1991",http://ufcstats.com/fighter-details/957562fdf68a725a
-Billy Goff,--,170 lbs.,--,,"Jun 18, 1998",http://ufcstats.com/fighter-details/fa07345cc9db5cc9
-Denise Gomes,--,125 lbs.,--,,"Dec 30, 1999",http://ufcstats.com/fighter-details/cffb87059e645bd1
-Ahmad Hassanzada,--,155 lbs.,--,,"Nov 20, 1996",http://ufcstats.com/fighter-details/bf7a64d9ae343e86
-Claudia Leite,--,135 lbs.,--,,"Nov 04, 1996",http://ufcstats.com/fighter-details/90550a08f0b02b6f
-Caio Machado,--,145 lbs.,--,,"Jul 20, 1994",http://ufcstats.com/fighter-details/89839250eb25c9c1
-Roshan Mainam,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/b301292b1bc92bdb
-Francis Marshall,--,155 lbs.,--,,"Mar 09, 1999",http://ufcstats.com/fighter-details/5d495dec23d7c68e
-Connor Matthews,--,145 lbs.,--,,"May 31, 1992",http://ufcstats.com/fighter-details/36e78278a77006d4
-Eduardo Neves,--,265 lbs.,--,,"Mar 16, 2000",http://ufcstats.com/fighter-details/1d688fa375d9431c
-Ho Taek Oh,--,155 lbs.,--,,"Jul 20, 1993",http://ufcstats.com/fighter-details/5c020ee6ab450870
-Claudio Ribeiro,--,185 lbs.,--,,"Jul 17, 1992",http://ufcstats.com/fighter-details/972c456ff38b2015
-Esteban Ribovics,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/323d4ca260dfa0ba
-Jesus Santos Aguilar,--,125 lbs.,--,,"Mar 13, 1996",http://ufcstats.com/fighter-details/c051c2e12d692b8a
-Jeka Saragih,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/8841c126a8ea629a
-Erik Silva,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/21b813b919776d90
-Danilo Suzart,--,251 lbs.,--,,"Apr 12, 1991",http://ufcstats.com/fighter-details/3d99e5aa85d7576a
-Ivan Valenzuela,--,185 lbs.,--,,"Nov 17, 1992",http://ufcstats.com/fighter-details/45b82ebf0b9e0fd2
-Rayanne Amanda,--,115 lbs.,--,,"Jun 08, 1995",http://ufcstats.com/fighter-details/02bb48869eb7ac8f
-Rodolfo Bellato,--,205 lbs.,--,,"Feb 05, 1996",http://ufcstats.com/fighter-details/69898645d600abdb
-Tereza Bleda,--,115 lbs.,--,,--,http://ufcstats.com/fighter-details/59c438c81fbf3ece
-Waldo Cortes-Acosta,--,265 lbs.,--,,"Oct 03, 1991",http://ufcstats.com/fighter-details/fc08099550072fe4
-Ozzy Diaz,--,185 lbs.,--,,"Nov 22, 1990",http://ufcstats.com/fighter-details/6967153c7edb4d87
-Viktoriia Dudakova,--,115 lbs.,--,,"Jan 26, 1999",http://ufcstats.com/fighter-details/6c9b66b43663f2f7
-Sedriques Dumas,--,185 lbs.,--,,"Aug 06, 1995",http://ufcstats.com/fighter-details/4e6738062d469256
-Stephen Erczeg,--,125 lbs.,--,,"Jul 27, 1995",http://ufcstats.com/fighter-details/32ab52e5de93092d
-Sandra Lavado,--,115 lbs.,--,,"May 03, 1994",http://ufcstats.com/fighter-details/aa6da8cb3a26da04
-Rodrigo Lidio,--,155 lbs.,--,,"Jul 07, 1989",http://ufcstats.com/fighter-details/11b5a809c3120e27
-Nayara Maia,--,125 lbs.,--,,"Jul 25, 1990",http://ufcstats.com/fighter-details/03b1b79b34eaf217
-Michael Parkin,--,265 lbs.,--,,"Oct 02, 1995",http://ufcstats.com/fighter-details/0d5cc0170c1a7e71
-Thomas Paull,--,155 lbs.,--,,"Oct 15, 1994",http://ufcstats.com/fighter-details/dda67d7d3df6b406
-Matej Penaz,--,185 lbs.,--,,"Oct 14, 1996",http://ufcstats.com/fighter-details/abd64006fd37298d
-Vitor Petrino,--,205 lbs.,--,,"Aug 28, 1997",http://ufcstats.com/fighter-details/71171fc96445bf65
-Mateusz Rebecki,--,155 lbs.,--,,"Nov 03, 1992",http://ufcstats.com/fighter-details/849c5d9979df5357
-Paulo Renato Jr.,--,265 lbs.,--,,"Jan 25, 1994",http://ufcstats.com/fighter-details/01dfb60661153735
-Kaleio Romero,--,145 lbs.,--,,"Apr 19, 1996",http://ufcstats.com/fighter-details/33df417d0017eb0c
-Shannon Ross,--,125 lbs.,--,,"May 12, 1989",http://ufcstats.com/fighter-details/51c655162e462ceb
-Nazim Sadykhov,--,155 lbs.,--,,"May 16, 1994",http://ufcstats.com/fighter-details/ff62013d2fce6d13
-Willian Souza,--,135 lbs.,--,,"Jun 21, 1986",http://ufcstats.com/fighter-details/dfc7f0a2d91ad337
-Oumar Sy,--,205 lbs.,--,,"Nov 21, 1995",http://ufcstats.com/fighter-details/46e2011d92463b7e
-Karolina Wojcik,--,115 lbs.,--,,"Dec 09, 1994",http://ufcstats.com/fighter-details/b99b3620839ea911
-Jimmy Lawson,--,265 lbs.,--,,"Nov 13, 1991",http://ufcstats.com/fighter-details/e43eefb10d440cb0
-Melissa Martinez,--,115 lbs.,--,,--,http://ufcstats.com/fighter-details/3f4c3bc822bea45d
-Kevin Szaflarski,--,260 lbs.,--,,"Dec 30, 1994",http://ufcstats.com/fighter-details/d2d05dda5f887f87
-Daniel Argueta,"5' 7""",145 lbs.,"70""",Southpaw,"Aug 13, 1993",http://ufcstats.com/fighter-details/e4ba58725825412d
-Jeka Saragih,"5' 8""",155 lbs.,--,Orthodox,"Jan 01, 1995",http://ufcstats.com/fighter-details/57186c150c645200
-Tainara Lisboa,"5' 6""",135 lbs.,--,,"Mar 02, 1991",http://ufcstats.com/fighter-details/2c5f5749569eef66
-Ailin Perez,"5' 5""",135 lbs.,--,,"Oct 05, 1994",http://ufcstats.com/fighter-details/06e4245d16fc5315
-Chelsea Chandler,--,145 lbs.,--,,"Nov 23, 1990",http://ufcstats.com/fighter-details/af9efbfd63d39734
-Emily Ducote,--,115 lbs.,--,,"Jan 01, 1994",http://ufcstats.com/fighter-details/02f8fedc18cbd26c
-Young Hwang,"5' 9""",135 lbs.,--,,"Sep 02, 1988",http://ufcstats.com/fighter-details/8588d14c4952b9fa
-Jinnosuke Kashimura,"5' 8""",155 lbs.,--,,"Aug 12, 2001",http://ufcstats.com/fighter-details/4a9120fa47bafef0
-Tetsuya Seki,"5' 10""",155 lbs.,--,,"Feb 08, 1994",http://ufcstats.com/fighter-details/5e1062e066c601e6
-Asjabharan,"5' 6""",135 lbs.,--,,"Jul 31, 1992",http://ufcstats.com/fighter-details/8be9deb7d6b36354
-Ikram Aliskerov,"6' 0""",185 lbs.,--,,"Dec 07, 1992",http://ufcstats.com/fighter-details/b07aed698fba8624
-Leon Aliu,"6' 0""",185 lbs.,--,,"Jul 14, 1989",http://ufcstats.com/fighter-details/6db394bf6c3b017c
-Bruna Brasil,"5' 6""",115 lbs.,--,,"Sep 07, 1993",http://ufcstats.com/fighter-details/7138a15258dabf20
-Roy Echeverria,"5' 5""",125 lbs.,--,,"Aug 21, 1995",http://ufcstats.com/fighter-details/20b13e96668caaa4
-Bruno Ferreira,"5' 8""",135 lbs.,--,,"May 13, 1988",http://ufcstats.com/fighter-details/1e719d4b676dc19a
-Jafel Filho,"5' 7""",125 lbs.,--,,--,http://ufcstats.com/fighter-details/65adf3856c4d9256
-Marnic Mann,"5' 0""",115 lbs.,--,,--,http://ufcstats.com/fighter-details/b6203e0492a9336c
-Joao Elias,"5' 3""",135 lbs.,--,,"Jan 08, 1995",http://ufcstats.com/fighter-details/1a064688481f66e1
-Rafael Estevam,"5' 8""",125 lbs.,--,,"Aug 10, 1996",http://ufcstats.com/fighter-details/83455a9d17f57dae
-Richard Jacobi,--,265 lbs.,--,,--,http://ufcstats.com/fighter-details/46f557bd44da630e
-Darrius Flowers,"5' 9""",170 lbs.,--,,"Aug 25, 1994",http://ufcstats.com/fighter-details/65db4065e2bc107d
-Amiran Gogoladze,"6' 0""",170 lbs.,--,,"Dec 09, 1997",http://ufcstats.com/fighter-details/5d1636b6c1688502
-Josh Kim,"5' 9""",135 lbs.,--,,"Nov 16, 1992",http://ufcstats.com/fighter-details/d538f13ab21d9633
-Cameron Saaiman,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/3c8a5200436e19f3
-Hamdy Abdelwahab,"6' 2""",261 lbs.,--,,"Jan 22, 1993",http://ufcstats.com/fighter-details/3329d692aea4dc28
-Zachary Borrego,"6' 2""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/b8fdb2903a2582a8
-Bo Nickal,"6' 1""",185 lbs.,--,,"Jan 14, 1996",http://ufcstats.com/fighter-details/35673bf5204524ee
-Nariman Abbasov,"5' 8""",155 lbs.,--,,"Feb 01, 1994",http://ufcstats.com/fighter-details/59a9d6dac61c2540
-Gabriel Bonfim,"6' 0""",170 lbs.,--,,"Aug 20, 1997",http://ufcstats.com/fighter-details/01641ba5df0c69b0
-Ismael Bonfim,"5' 8""",155 lbs.,--,,"Dec 28, 1995",http://ufcstats.com/fighter-details/eb393afdbe3293d5
-Edgar Chairez,"5' 7""",135 lbs.,--,,"Jan 27, 1996",http://ufcstats.com/fighter-details/5ef94841c4bc3f86
-Felix Klinkhammer,"6' 0""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/8276f28f1ad087de
-Garrett Armfield,"5' 6""",145 lbs.,"70""",Orthodox,"Oct 09, 1996",http://ufcstats.com/fighter-details/1effd880e1f1bb30
-Juliana Miller,"5' 7""",125 lbs.,--,,"May 07, 1996",http://ufcstats.com/fighter-details/aa0c573da7119292
-Mohammed Usman,"6' 2""",239 lbs.,--,,"Apr 01, 1989",http://ufcstats.com/fighter-details/da7f113b5ea39c43
-Brogan Walker,"5' 4""",125 lbs.,--,,"Aug 02, 1989",http://ufcstats.com/fighter-details/4333a8e70a672eb7
-Blake Bilder,"5' 8""",145 lbs.,--,,"Jul 12, 1990",http://ufcstats.com/fighter-details/5095b0920a3602aa
-Jose Henrique,"6' 4""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/20a0e4cc5227c117
-Yusaku Kinoshita,"6' 0""",170 lbs.,--,,"Aug 21, 2000",http://ufcstats.com/fighter-details/21b5c82c1b89dab1
-Alex Morgan,"5' 10""",145 lbs.,--,,"May 14, 1991",http://ufcstats.com/fighter-details/938ea36fe9c269f0
-Iasmin Lucindo,"5' 3""",125 lbs.,--,,"Jan 08, 2002",http://ufcstats.com/fighter-details/abcf2cc6efc42031
-Zac Pauga,"6' 0""",205 lbs.,--,,"Feb 25, 1988",http://ufcstats.com/fighter-details/56f7d7ee06be4aab
-Adam Fugitt,"6' 1""",170 lbs.,--,Southpaw,"Jan 12, 1989",http://ufcstats.com/fighter-details/a01a62132460a98d
-Cedric Doumbe,"5' 10""",170 lbs.,--,,"Aug 13, 1992",http://ufcstats.com/fighter-details/5159e6ee100c717e
-Da'Mon Blackshear,--,145 lbs.,--,,"Aug 12, 1994",http://ufcstats.com/fighter-details/da22387a0407a2dc
-Tamires Vidal,"5' 5""",135 lbs.,--,,"Jul 27, 1998",http://ufcstats.com/fighter-details/4f3064faf17aa711
-Donovan Beard,"6' 2""",185 lbs.,--,,--,http://ufcstats.com/fighter-details/3a6ac598320ca7f2
-Ashiek Ajim,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/49dea784f6cfed71
-Allan Begosso,"5' 4""",135 lbs.,--,,"Nov 23, 1995",http://ufcstats.com/fighter-details/d6ed764f8b78d32a
-Vinicius Cenci,--,155 lbs.,--,,"Nov 24, 1995",http://ufcstats.com/fighter-details/f21a152aaa3e95c6
-Freddy Emiliano Linares,--,145 lbs.,--,,"Apr 21, 1997",http://ufcstats.com/fighter-details/a4ef92274a45143d
-Mando Gutierrez,"5' 6""",135 lbs.,--,,"Feb 24, 1997",http://ufcstats.com/fighter-details/5f33ae0620e050c5
-Jack Jenkins,"5' 7""",145 lbs.,--,,--,http://ufcstats.com/fighter-details/a9da3158dd2c2b5a
-Daniel Marcos,"5' 7""",135 lbs.,--,,"Mar 07, 1993",http://ufcstats.com/fighter-details/850266b3dc4e506e
-Mateus Mendonca,"5' 6""",135 lbs.,--,,"Jan 17, 1999",http://ufcstats.com/fighter-details/48812daf291a4e23
-Gabriel Miranda,"5' 11""",145 lbs.,--,,"Mar 25, 1990",http://ufcstats.com/fighter-details/b909a9a9688b5284
-Sam Patterson,"6' 4""",155 lbs.,--,,"Apr 30, 1996",http://ufcstats.com/fighter-details/8b6e5dc2ba1edbe7
-Raul Rosas Jr.,"5' 9""",135 lbs.,--,,"Oct 08, 2004",http://ufcstats.com/fighter-details/fe2babf95de24fb1
-Michal Figlak,"5' 10""",155 lbs.,--,,"Aug 15, 1996",http://ufcstats.com/fighter-details/b4c57a8c2b773e82
-Themba Gorimbo,"6' 0""",170 lbs.,--,,--,http://ufcstats.com/fighter-details/40f3cb27fc7305a1
-Malik Lewis,"6' 0""",155 lbs.,--,,--,http://ufcstats.com/fighter-details/f60dbe6e05489c4f
-Nurullo Aliev,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/ca28cdf526d6b6e9
-Nair Melikyan,"5' 6""",155 lbs.,--,,"Aug 08, 1997",http://ufcstats.com/fighter-details/64b8561624d3b15e
-Trevor Peek,"5' 9""",170 lbs.,--,,"Jan 09, 1995",http://ufcstats.com/fighter-details/0bc697c5936a2d0a
-Trey Waters,"6' 5""",170 lbs.,--,,"Feb 21, 1995",http://ufcstats.com/fighter-details/31dbfbe4e7a6727c
-Jarno Errens,"5' 11""",145 lbs.,--,,"Nov 17, 1994",http://ufcstats.com/fighter-details/082eba4cd80f736f
-William Gomis,--,145 lbs.,--,,"Jun 13, 1997",http://ufcstats.com/fighter-details/e1d40e8782d80bc2
-Karl Williams,"6' 3""",205 lbs.,--,,"Jan 06, 1990",http://ufcstats.com/fighter-details/d35f734c56a89103
-Irina Alekseeva,"5' 8""",135 lbs.,--,,"Jun 27, 1990",http://ufcstats.com/fighter-details/103e2e33a60683e1
-Slim Trabelsi,"6' 3""",235 lbs.,--,,"May 09, 1993",http://ufcstats.com/fighter-details/ff2ec83f44000f78
-Don Shainis,"5' 6""",145 lbs.,--,,"Sep 16, 1990",http://ufcstats.com/fighter-details/da4628f173337902
-Josh Wick,"5' 9""",155 lbs.,--,Switch,"Oct 04, 1994",http://ufcstats.com/fighter-details/13935768cf8aeb86
-Jaqueline Amorim,"5' 3""",115 lbs.,--,,"Jun 24, 1995",http://ufcstats.com/fighter-details/bc7d1ad49fcb2d08
-Yamato Nishikawa,"5' 7""",170 lbs.,--,,"Dec 06, 2002",http://ufcstats.com/fighter-details/7beecbe0a08cf002
-Lucas Alexander,"5' 10""",145 lbs.,--,,"Jul 28, 1995",http://ufcstats.com/fighter-details/11583163f45c7b31
-Gian Siqueira,--,170 lbs.,--,,"Jun 23, 1994",http://ufcstats.com/fighter-details/a46fdda658fee832
-Samandar Murodov,--,170 lbs.,--,,"Aug 28, 1999",http://ufcstats.com/fighter-details/6f4d199c0adc06f5
-Carlos Mota,"5' 6""",125 lbs.,--,,"Apr 15, 1995",http://ufcstats.com/fighter-details/b15862fcd6ded451
-Gabriella Fernandes,"5' 6""",125 lbs.,--,,"Aug 13, 1993",http://ufcstats.com/fighter-details/a6eb54ae17a551be
-Isaac Dulgarian,--,145 lbs.,--,,"Jul 04, 1996",http://ufcstats.com/fighter-details/a57cb948c4c70a47
-Yanal Ashmoz,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/c739c2995a275314
-Gaston Bolanos,--,145 lbs.,--,,"Sep 14, 1992",http://ufcstats.com/fighter-details/96924b0019b3aff1
-Steven Koslow,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/84512339473dd300
-Luan Lacerda,"5' 7""",135 lbs.,--,,"Jan 07, 1993",http://ufcstats.com/fighter-details/6fc506e1099afe20
-Nick Fiore,"5' 11""",155 lbs.,--,,"Dec 10, 1997",http://ufcstats.com/fighter-details/036e96c1c12b8a59
-Shara Magomedov,"6' 2""",170 lbs.,--,,"May 16, 1994",http://ufcstats.com/fighter-details/06734ca9d88dec3a
-Melquizael Costa,"5' 10""",155 lbs.,--,,"Sep 14, 1996",http://ufcstats.com/fighter-details/20bccc9bb4ceb23e
-Francisco Prado,"5' 10""",155 lbs.,--,,"Jun 16, 2002",http://ufcstats.com/fighter-details/3920d0cc288f9b0d
-Nick Aguirre,"5' 9""",145 lbs.,--,,"Jan 15, 1996",http://ufcstats.com/fighter-details/0978385b2bd9ef9b
-Christian Duncan,"6' 2""",185 lbs.,--,,"Jul 24, 1995",http://ufcstats.com/fighter-details/a93f94c923c3a9cb
-Elves Brenner,"5' 9""",155 lbs.,--,,"Sep 27, 1997",http://ufcstats.com/fighter-details/48a9a128784d53d1
-Rolando Bedoya,--,170 lbs.,--,,"Jan 13, 1997",http://ufcstats.com/fighter-details/40a456a25d52ee65
-Carl Deaton,"5' 6""",155 lbs.,--,,"Nov 24, 1989",http://ufcstats.com/fighter-details/914a897455693650
-Loik Radzhabov,--,155 lbs.,--,Orthodox,"Sep 17, 1990",http://ufcstats.com/fighter-details/8c169fbe1ac33637
-Mark Climaco,--,125 lbs.,--,,"Nov 06, 1997",http://ufcstats.com/fighter-details/60098849c703e389
-Ji Niushiyue,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/c14a683dac2ebc4c
-Sumit Kumar,--,135 lbs.,--,,"Sep 09, 2000",http://ufcstats.com/fighter-details/a0a625221e0dd339
-Jung Hyun Lee,--,125 lbs.,--,,"Sep 10, 2002",http://ufcstats.com/fighter-details/b6033505c245e28b
-Billy Pasulatan,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/e5a59983f4603621
-Ronal Siahaan,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/762226efa2b01654
-Rei Tsuruya,--,125 lbs.,--,,"Jun 22, 2002",http://ufcstats.com/fighter-details/2f43a3e82661fa99
-Gabriel Santos,--,145 lbs.,--,,"Nov 28, 1996",http://ufcstats.com/fighter-details/f2f140ce7532e327
-Reza Arianto,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/90063913321e7670
-Abdul Azeem Badakhshi,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/968764372c49eab6
-Bahatebole Batebolati,--,170 lbs.,--,,"Sep 12, 1997",http://ufcstats.com/fighter-details/8f313e9c3a39c06e
-Eperaim Ginting,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/bad8ed7d714f1493
-Shin Haraguchi,--,155 lbs.,--,,"Nov 27, 1998",http://ufcstats.com/fighter-details/05b17ae24e6bba81
-Sung Chan Hong,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/10d4575f497face4
-Baergeng Jieleyisi,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/8677e67a75d65b8e
-Shuya Kamikubo,--,145 lbs.,--,,"Apr 12, 1995",http://ufcstats.com/fighter-details/a46fa1c7972548d0
-Kouya Kanda,--,--,--,,"Dec 20, 1995",http://ufcstats.com/fighter-details/b42d3a1469dab722
-Sang Uk Kim,--,--,--,,--,http://ufcstats.com/fighter-details/a264d4e9a4d6bfe4
-Chang Ho Lee,--,125 lbs.,--,,"May 09, 1994",http://ufcstats.com/fighter-details/117a06469813e4ef
-Li Kaiwen,--,145 lbs.,--,,"Oct 16, 1995",http://ufcstats.com/fighter-details/0565706b1e7f7e7c
-Kazuma Maruyama,--,170 lbs.,--,,"Jul 19, 1992",http://ufcstats.com/fighter-details/aa1a873d05acc7eb
-Wendris Patilima,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/66d42e9503fa108e
-Rana Rudra Pratap Singh,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/254ed71756cfd18c
-Joshua Van,--,125 lbs.,--,,"Oct 10, 2001",http://ufcstats.com/fighter-details/17e97649403ba428
-Yibugele,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/cc2fcae2c0dc501d
-Daermisi Zhawupasi,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/fd52e5f9ab25c94c
-Sang Won Kim,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/e9712cad24948ce1
-Taiyilake Nueraji,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/7498b3ac79a3b948
-Peter Danesoe,--,135 lbs.,--,,"Sep 01, 2000",http://ufcstats.com/fighter-details/5f119b24c0f9679c
-Chris Hofmann,--,170 lbs.,--,,"Nov 18, 1989",http://ufcstats.com/fighter-details/33fb306278dbb3e5
-Sim Kai Xiong,--,135 lbs.,--,,"Sep 06, 1997",http://ufcstats.com/fighter-details/79e2cb1e813f881b
-Nyamjargal Tumendemberel,--,125 lbs.,--,,"Mar 22, 1998",http://ufcstats.com/fighter-details/17cb6d8e8187f304
-Assu Almabayev,--,125 lbs.,--,,"Jan 25, 1994",http://ufcstats.com/fighter-details/8d3273573b85be09
-Azat Maksum,--,125 lbs.,--,,"Feb 02, 1995",http://ufcstats.com/fighter-details/7f1bf0c255ec8756
-Braxton Smith,--,257 lbs.,--,,"Jan 01, 1990",http://ufcstats.com/fighter-details/eaa9402e5a7990ad
-Eli Aronov,--,185 lbs.,--,,"Jun 06, 1996",http://ufcstats.com/fighter-details/a90c200c3fbb22c4
-Felipe dos Santos,--,125 lbs.,--,,"Sep 11, 2000",http://ufcstats.com/fighter-details/5cdf5339728f580d
-Zach Reese,--,185 lbs.,--,,"Mar 24, 1994",http://ufcstats.com/fighter-details/23dec7c47cb418f8
-Isis Verbeek,--,115 lbs.,--,,"Jan 12, 1995",http://ufcstats.com/fighter-details/d6f58b8cd1a6ff52
-Ivana Petrovic,--,125 lbs.,--,,"Jun 11, 1994",http://ufcstats.com/fighter-details/38c5817ade8a8014
-Marcus McGhee,--,135 lbs.,--,,"May 07, 1990",http://ufcstats.com/fighter-details/c0ac37a4a1133da9
-Chandler Cole,--,--,--,,"Jan 09, 1995",http://ufcstats.com/fighter-details/5d8a9c95af50280a
-Eduarda Moura,--,115 lbs.,--,,"Feb 28, 1994",http://ufcstats.com/fighter-details/de594b35c45c2e9a
-Thomas Petersen,--,255 lbs.,--,,"Mar 30, 1995",http://ufcstats.com/fighter-details/764d39074a352e33
-Janaina Silva,--,115 lbs.,--,,"Feb 16, 1992",http://ufcstats.com/fighter-details/4784a5b4a452464a
-Marco Tulio,--,185 lbs.,--,,"Aug 30, 1994",http://ufcstats.com/fighter-details/9384e71bca6c409d
-Val Woodburn,--,185 lbs.,--,,"Aug 10, 1993",http://ufcstats.com/fighter-details/7a47e068f8017019
-Bogdan Grad,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/fb37795db81f93f3
-Tom Nolan,--,155 lbs.,--,,"Mar 08, 2000",http://ufcstats.com/fighter-details/6c3b2525436cf5d4
-Ketlen Souza,--,125 lbs.,--,,"Aug 18, 1994",http://ufcstats.com/fighter-details/8bd4200561c77a62
-Payton Talbott,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/6e743a33d56bdaa4
-Cesar Almeida,--,185 lbs.,--,,"Mar 23, 1988",http://ufcstats.com/fighter-details/64d47ef881a437a4
-Kevin Borjas,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/34b96d52db1d26e6
-Stephen Erceg,--,125 lbs.,--,,"Jul 27, 1995",http://ufcstats.com/fighter-details/9411103a865f32d3
-Lucas Fernando,--,185 lbs.,--,,--,http://ufcstats.com/fighter-details/3df223aeaacecf3f
-Wuziazibieke Jiahefu,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/2d077e22886298be
-Feng Pengchao,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/86597694317e5e1b
-Junye Gao,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/8b27d25ce0221d60
-Lu Zhengyong,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/dc1bfd47c3b21ad3
-Patricia Alujas,--,115 lbs.,--,,--,http://ufcstats.com/fighter-details/430c533614d45813
-Felipe Bunes,--,125 lbs.,--,,"Oct 26, 1989",http://ufcstats.com/fighter-details/53c10176e3bc7416
-Jhonata Deniz,--,--,--,,--,http://ufcstats.com/fighter-details/25f9a5f3e8a52618
-Raine Guerrero,--,115 lbs.,--,,"May 13, 1992",http://ufcstats.com/fighter-details/8300a47f6fd6fe4f
-Chad Hanekom,--,185 lbs.,--,,--,http://ufcstats.com/fighter-details/98533a2738124a0d
-Corinne Laframboise,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/fbe9f4efc2153be2
-Bruno Lopes,--,205 lbs.,--,,"Apr 24, 1993",http://ufcstats.com/fighter-details/0abcf6bc47191219
-Brendson Ribeiro,--,205 lbs.,--,,"Aug 09, 1996",http://ufcstats.com/fighter-details/49edd0d90f60fb7d
-Cameron Rowston,--,185 lbs.,--,,"Jan 19, 1995",http://ufcstats.com/fighter-details/8ebc3a8da015d70c
-Stephanie Bruna,--,115 lbs.,--,,"Dec 16, 1999",http://ufcstats.com/fighter-details/1b35af4d1529adf6
-Igor Da Silva,--,125 lbs.,--,,"Apr 21, 2003",http://ufcstats.com/fighter-details/6ad8e4296f7522d9
-Shamil Gaziev,--,--,--,,--,http://ufcstats.com/fighter-details/6747ccd6d1acd266
-Fabiola Pidroni,--,115 lbs.,--,,"Jan 04, 1994",http://ufcstats.com/fighter-details/9561eb5f0d63ffcc
-Jhonata Silva,--,125 lbs.,--,,"Apr 24, 1997",http://ufcstats.com/fighter-details/4e33534d1e036444
-Greg Velasco,--,--,--,,"Sep 23, 1993",http://ufcstats.com/fighter-details/34a81ebbce32b06b
-Cyborg Abreu,--,--,--,,"Dec 20, 1980",http://ufcstats.com/fighter-details/f689bd7bbd14b392
-Hyder Amil,--,145 lbs.,--,,"May 28, 1990",http://ufcstats.com/fighter-details/41cc71cbf210e0fe
-Fellipe Andrew,--,--,--,,"Oct 24, 1994",http://ufcstats.com/fighter-details/7977fb0fd9c5955d
-Gabriel Arges,--,170 lbs.,--,,"Jan 29, 1993",http://ufcstats.com/fighter-details/db3c4a884d704efe
-Roman Bravo-Young,--,205 lbs.,--,,--,http://ufcstats.com/fighter-details/37ce890a4670b287
-Charalampos Grigoriou,--,135 lbs.,--,,"Mar 31, 1992",http://ufcstats.com/fighter-details/68b8ebdfce9dbb61
-Craig Jones,--,205 lbs.,--,,"Jul 17, 1991",http://ufcstats.com/fighter-details/e947b563eb744a21
-Dan Manasoiu,--,--,--,,--,http://ufcstats.com/fighter-details/eefc73b53d4a05d7
-Nick Meregali,--,--,--,,--,http://ufcstats.com/fighter-details/2f6dc878d653c442
-Fedor Nikolov,--,--,--,,--,http://ufcstats.com/fighter-details/346f789951e85f3f
-Felipe Pena,--,--,--,,"Oct 19, 1991",http://ufcstats.com/fighter-details/566ff9546fc29acd
-Haisam Rida,--,--,--,,"Jul 25, 1993",http://ufcstats.com/fighter-details/d8a58e797518f011
-Cameron Smotherman,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/5c84f673b7bb7c15
-Emrah Sonmez,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/fe759b24e344d7eb
-Kaik Brito,--,155 lbs.,--,,"Mar 26, 1997",http://ufcstats.com/fighter-details/b07f14fc0e53f8bd
-Timothy Cuamba,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/0e46690e55a8df75
-Oban Elliott,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/6b56e94a59b7b134
-George Hardwick,--,155 lbs.,--,,"Dec 06, 1996",http://ufcstats.com/fighter-details/f55a6807b6bb853d
-Tobias Harila,--,--,--,,"Jan 13, 1994",http://ufcstats.com/fighter-details/4d1e92b61bcef308
-Bolaji Oki,--,155 lbs.,--,,"Nov 15, 1995",http://ufcstats.com/fighter-details/4bdedbdeedff7d1d
-Luis Pajuelo,--,145 lbs.,--,,"Dec 12, 1994",http://ufcstats.com/fighter-details/e530df53922f413e
-Pedro Rocha,--,--,--,,--,http://ufcstats.com/fighter-details/5921fd3f889afa3b
-Dylan Salvador,--,155 lbs.,--,,"May 20, 1993",http://ufcstats.com/fighter-details/a7a3fb5f6c67b122
-Jean Silva,--,145 lbs.,--,,"Dec 13, 1996",http://ufcstats.com/fighter-details/52ef95b5860fb28c
-Kevin Vallejos,--,145 lbs.,--,,"Dec 08, 2001",http://ufcstats.com/fighter-details/239d8e5359022f3b
-Mateo Vogel,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/90b57b19d20e1969
-Abdul-Kareem Al-Selwady,--,155 lbs.,--,,"Apr 10, 1995",http://ufcstats.com/fighter-details/597499ac7a5aac62
-Carlos Prates,--,170 lbs.,--,,"Aug 17, 1993",http://ufcstats.com/fighter-details/7ee0fd831c0fe7c3
-Mitch Ramirez,--,170 lbs.,--,,"Nov 03, 1992",http://ufcstats.com/fighter-details/e99eb0ef25885de5
-Ramon Taveras,--,145 lbs.,--,,"Jan 09, 1994",http://ufcstats.com/fighter-details/c5ccd878231c5407
-Jesse Butler,--,155 lbs.,--,,"May 24, 1992",http://ufcstats.com/fighter-details/a75a48bfe776b2c2
-Talita Alencar,--,115 lbs.,--,,"Oct 17, 1990",http://ufcstats.com/fighter-details/d35298b6df168456
-Shauna Bannon,--,115 lbs.,--,,"Oct 23, 1993",http://ufcstats.com/fighter-details/9c442aaf149ea982
-Luana Santos,--,125 lbs.,--,,"Apr 16, 2000",http://ufcstats.com/fighter-details/5078e1dacf9d25f4
-Montserrat Rendon,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/60193e707634e560
-Helena Crevar,--,--,--,,--,http://ufcstats.com/fighter-details/a8c3ce469cb8b130
-Melissa Dixon,--,135 lbs.,--,,"Jul 23, 1991",http://ufcstats.com/fighter-details/bd532e9a2b93870c
-Emily Fernandez,--,--,--,,--,http://ufcstats.com/fighter-details/7ee1babb99f30115
-Dariya Zheleznykova,--,135 lbs.,--,,"Jan 23, 1996",http://ufcstats.com/fighter-details/07047eb7d17fb0a2
-Nora Cornolle,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/f2b3f4ef3f780168
-Robbie Ring,--,145 lbs.,--,,"Jul 14, 2000",http://ufcstats.com/fighter-details/fa9746fa5d23c202
-Jose Mariscal,--,155 lbs.,--,,"Oct 27, 1992",http://ufcstats.com/fighter-details/e0c6edcb5b5d0b90
-Jacqueline Cavalcanti,--,135 lbs.,--,,"Aug 29, 1997",http://ufcstats.com/fighter-details/e3964ece586e0635
-Serhiy Sidey,--,135 lbs.,--,,"Jul 04, 1996",http://ufcstats.com/fighter-details/1a2bf44edb8055b6
-Valter Walker,--,--,--,,"Dec 14, 1997",http://ufcstats.com/fighter-details/f5779a2303ed76ec
-Rickson Zenidim,--,125 lbs.,--,,"Feb 17, 1999",http://ufcstats.com/fighter-details/c879d8620261b1a3
-Nursulton Ruziboev,--,185 lbs.,--,,"Nov 19, 1993",http://ufcstats.com/fighter-details/49d2a08964c5eb11
-Terrence Mitchell,--,135 lbs.,--,,"Dec 30, 1989",http://ufcstats.com/fighter-details/f3ca6908f78efebe
-Westin Wilson,--,145 lbs.,--,,"Jan 24, 1989",http://ufcstats.com/fighter-details/7b3503352cd53abb
-Ernesta Kareckaite,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/e4faa79383c9f214
-Mario Piazzon,--,--,--,,"Apr 06, 1998",http://ufcstats.com/fighter-details/44f234a36324e6c8
-Sora Rakhmonova,--,--,--,,"Jun 21, 1998",http://ufcstats.com/fighter-details/63ff619c52ff7976
-Alexander Soldatkin,--,--,--,,"Jun 10, 1993",http://ufcstats.com/fighter-details/f1451d605bad178e
-Davi Costa,--,125 lbs.,--,,"Dec 10, 1994",http://ufcstats.com/fighter-details/dd6ec6f941c3a414
-AJ Cunningham,--,145 lbs.,--,,"Sep 07, 1994",http://ufcstats.com/fighter-details/d1053e55f00e53fe
-Magomed Gadzhiyasulov,--,205 lbs.,--,,"Nov 04, 1993",http://ufcstats.com/fighter-details/6e344b71421103da
-James Llontop,--,155 lbs.,--,,"Aug 02, 1999",http://ufcstats.com/fighter-details/93b2b7caa457cbea
-Jean Matsumoto,--,135 lbs.,--,,"Sep 09, 1999",http://ufcstats.com/fighter-details/ffd3224638c01b57
-Jose Medina,--,205 lbs.,--,,--,http://ufcstats.com/fighter-details/baa9be02c3e3e038
-Luciano Pereira,--,125 lbs.,--,,"Jan 09, 2001",http://ufcstats.com/fighter-details/d7ee49bf3c779fa6
-Lucas Rocha,--,125 lbs.,--,,"Aug 12, 2000",http://ufcstats.com/fighter-details/e0d3d9b564f95635
-Murtaza Talha,--,205 lbs.,--,,--,http://ufcstats.com/fighter-details/6aab5c20395ee722
-Kasey Tanner,--,135 lbs.,--,,"Jan 11, 1992",http://ufcstats.com/fighter-details/078b732efa497f49
-Josiah Harrell,--,170 lbs.,--,Southpaw,"Nov 13, 1998",http://ufcstats.com/fighter-details/e5864a42c80294f6
-Yousri Belgaroui,--,185 lbs.,--,,"Jul 07, 1987",http://ufcstats.com/fighter-details/7674b836ce0698a0
-Charlie Radtke,--,170 lbs.,--,,"Jul 09, 1990",http://ufcstats.com/fighter-details/feedf3053472fe56
-Bassil Hafez,--,170 lbs.,--,,"Jan 31, 1992",http://ufcstats.com/fighter-details/f4d92416da98804b
-Rami Hamed,--,170 lbs.,--,,"Apr 25, 1991",http://ufcstats.com/fighter-details/a59017211b775b5d
-Kaynan Kruschewsky,--,155 lbs.,--,,"Apr 04, 1991",http://ufcstats.com/fighter-details/ca36633b80be4a78
-Raimond Magomedaliev,--,170 lbs.,--,,"Jun 10, 1990",http://ufcstats.com/fighter-details/d16373b3568678d4
-Dylan Mantello,--,155 lbs.,--,,"Nov 19, 1992",http://ufcstats.com/fighter-details/e192ebb85b68fa9e
-Danny Barlow,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/b7c5eb7cdbac6a63
-Vinicius de Oliveira,--,135 lbs.,--,,"Nov 30, 1995",http://ufcstats.com/fighter-details/18d01f7f8338ae72
-Bogdan Guskov,--,205 lbs.,--,,"Sep 12, 1992",http://ufcstats.com/fighter-details/ef5dcb10d2bd4b0f
-Victor Madrigal,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/cc63a5f0089d8ba9
-Angel Pacheco,--,145 lbs.,--,,"Jan 13, 1992",http://ufcstats.com/fighter-details/07797f10b9569cfc
-Danny Silva,--,145 lbs.,--,,"Jan 30, 1997",http://ufcstats.com/fighter-details/d964a59c48381cb6
-Victor Dias,--,125 lbs.,--,,"Dec 26, 1990",http://ufcstats.com/fighter-details/f7202b3130421d27
-Yanis Ghemmouri,--,135 lbs.,--,,"Jan 24, 1995",http://ufcstats.com/fighter-details/eb70e786bbdf1d16
-Caolan Loughran,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/42ac4020cba261ad
-Dan Allen,--,155 lbs.,--,,"Aug 10, 1992",http://ufcstats.com/fighter-details/adf9a901308fb8e3
-Jacobi Jones,--,155 lbs.,--,,"May 24, 1996",http://ufcstats.com/fighter-details/08b01ed84044c6bc
-Morgan Charriere,--,145 lbs.,--,,"Oct 26, 1995",http://ufcstats.com/fighter-details/5b03b61f9d90125e
-Manolo Zecchini,--,155 lbs.,--,,"Oct 22, 1996",http://ufcstats.com/fighter-details/fd7ab338e4953644
-Jae Hyun Park,--,155 lbs.,--,,"Dec 10, 2001",http://ufcstats.com/fighter-details/fe1595732dfb08fc
-Quillan Salkilld,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/17734443a833cdf7
-Jair Farias,--,145 lbs.,--,,"Mar 16, 1993",http://ufcstats.com/fighter-details/431262bbc69215dc
-Victor Hugo,--,135 lbs.,--,,"Nov 22, 1992",http://ufcstats.com/fighter-details/f264ba50b007f39e
-Issa Isakov,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/e9095aeb36f2aeb8
-Eduardo Matias Torres,--,135 lbs.,--,,"Apr 26, 1995",http://ufcstats.com/fighter-details/c8d46028907bcece
-Marquel Mederos,--,155 lbs.,--,,"Nov 30, 1996",http://ufcstats.com/fighter-details/e2be0c1a9b886d92
-Mauricio Ruffy,--,170 lbs.,--,,"Jun 17, 1993",http://ufcstats.com/fighter-details/9c393e836a852f30
-Torrez Finney,--,185 lbs.,--,,"Oct 24, 1998",http://ufcstats.com/fighter-details/fbb60f24af5d5a02
-Andre Lima,--,125 lbs.,--,,"Feb 04, 1999",http://ufcstats.com/fighter-details/b1f21ce050035d58
-Yuri Panferov,--,185 lbs.,--,,"Aug 30, 1996",http://ufcstats.com/fighter-details/36d811b015635b67
-Yuele Huang,--,145 lbs.,--,,"Jul 04, 2000",http://ufcstats.com/fighter-details/1c8b9f4d89b92e1b
-Kyu Sung Kim,--,125 lbs.,--,,"Nov 05, 1992",http://ufcstats.com/fighter-details/e7ecfab8fd86d3e1
-Ravena Oliveira Morais,--,135 lbs.,--,,"Feb 20, 1997",http://ufcstats.com/fighter-details/4948e412fa6ab67d
-Robert Bryczek,--,185 lbs.,--,,"Jul 04, 1990",http://ufcstats.com/fighter-details/f96856f9d69fd7e4
-Kiefer Crosbie,--,170 lbs.,--,,"Apr 05, 1990",http://ufcstats.com/fighter-details/4729c93ba705a3bf
-Kevin Jousset,--,170 lbs.,--,,"May 02, 1993",http://ufcstats.com/fighter-details/dda15dbfafb792df
-Dione Barbosa,--,125 lbs.,--,,"May 08, 1992",http://ufcstats.com/fighter-details/27b388f0aab49780
-Dylan Budka,--,185 lbs.,--,,"Jan 14, 2000",http://ufcstats.com/fighter-details/a817e238b2747404
-So Yul Kim,--,115 lbs.,--,,"May 25, 1997",http://ufcstats.com/fighter-details/864c07a7ff90caae
-Raheam Forest,--,170 lbs.,--,,"Jul 11, 1997",http://ufcstats.com/fighter-details/90390dd1b0791e7f
-Mohammad Yahya,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/3753714927f18437
-Cortavious Romious,--,135 lbs.,--,,"Jan 06, 1994",http://ufcstats.com/fighter-details/8173f134396cb971
-Carli Judice,--,125 lbs.,--,,"Mar 02, 1999",http://ufcstats.com/fighter-details/f1ab6f37492c630a
-Kaue Fernandes,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/ec13c393d029297d
-Brendon Marotte,--,155 lbs.,--,,"Jan 13, 1997",http://ufcstats.com/fighter-details/d7fe8c6b7d2872e5
-Puja Tomar,--,115 lbs.,--,,"Dec 05, 1993",http://ufcstats.com/fighter-details/19f8a2f6eecd92ac
-Myktybek Orolbai,--,170 lbs.,--,,"Feb 10, 1998",http://ufcstats.com/fighter-details/bf2c8e01b07d3eb1
-Carlos Vera,--,135 lbs.,--,,"Nov 05, 1987",http://ufcstats.com/fighter-details/07f959e6596307bb
-Robelis Despaigne,--,265 lbs.,--,,"Sep 09, 1988",http://ufcstats.com/fighter-details/140567899d98978a
-Kayla Harrison,--,135 lbs.,--,,"Jul 02, 1990",http://ufcstats.com/fighter-details/1af1170ed937cba7
-Bekzat Almakhan,--,135 lbs.,--,,"Sep 08, 1997",http://ufcstats.com/fighter-details/a4dc0f2b95df4cc1
-Benardo Sopaj,--,135 lbs.,--,,"Sep 25, 2000",http://ufcstats.com/fighter-details/b6c37948cb226e8c
-John Almanza,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/088aa1b19b2dc14a
-Angad Bisht,--,125 lbs.,--,,"Jun 05, 1995",http://ufcstats.com/fighter-details/7b4ae3fd439a05b6
-Dong Hoon Choi,--,125 lbs.,--,,"Jan 02, 1999",http://ufcstats.com/fighter-details/3be16d817b36098b
-Wang Cong,--,125 lbs.,--,,"May 15, 1992",http://ufcstats.com/fighter-details/2997e7fe3c9d3d4a
-Feier Huang,--,115 lbs.,--,,"Mar 12, 1994",http://ufcstats.com/fighter-details/e71c75f533a30daa
-Dong Huaxiang,--,115 lbs.,--,,"Aug 21, 1998",http://ufcstats.com/fighter-details/bad82b681819b272
-Paula Luna,--,125 lbs.,--,,"May 07, 1999",http://ufcstats.com/fighter-details/5b1effb0db45273a
-Miki Motono,--,115 lbs.,--,,"May 18, 1994",http://ufcstats.com/fighter-details/a5fa51a81d0c5ed9
-Kiru Sing Sahota,--,125 lbs.,--,,"May 28, 1995",http://ufcstats.com/fighter-details/296a120cb880477b
-Priya Sharma,--,115 lbs.,--,,"Aug 29, 1991",http://ufcstats.com/fighter-details/5f23eaf9e9c34667
-Ming Shi,--,115 lbs.,--,,"Nov 14, 1994",http://ufcstats.com/fighter-details/d683f4870742b273
-Yin Shuai,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/a78dc3910554dbae
-Kiran Singh,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/f985ca2370a37078
-Feng Xiaocan,--,115 lbs.,--,,"Dec 11, 2001",http://ufcstats.com/fighter-details/c940b42df95bbd28
-Kantharaj Agasa,--,135 lbs.,--,,"Feb 16, 1992",http://ufcstats.com/fighter-details/26f4288e83188c61
-Hamid Amiri,--,145 lbs.,--,,"Jun 15, 2003",http://ufcstats.com/fighter-details/6c40705cf6c0d7e2
-Masuto Kawana,--,145 lbs.,--,,"Jan 30, 1995",http://ufcstats.com/fighter-details/49f4171f14f54220
-Lisa Kyriacou,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/edbc609a3b0d2aba
-Toki Matsui,--,125 lbs.,--,,"Sep 08, 1999",http://ufcstats.com/fighter-details/56cc76c55cee8410
-Tokitaka Nakanishi,--,135 lbs.,--,,"Jul 28, 1996",http://ufcstats.com/fighter-details/eb9446a4f44e19cf
-Ren Ozaki,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/8997ee20b6a43d76
-Ruel Panales,--,125 lbs.,--,,"Dec 07, 1996",http://ufcstats.com/fighter-details/2742f028399bf8c7
-Young Jae Song,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/0efb0d4ebb950fcb
-Soo Young Yoo,--,135 lbs.,--,,"Dec 11, 1995",http://ufcstats.com/fighter-details/a474aade8eb3a8f0
-Zhu Kangjie,--,145 lbs.,--,,"Jan 15, 1996",http://ufcstats.com/fighter-details/6f4ec5aa3eced219
-Quang Le,--,135 lbs.,--,,"Oct 18, 1991",http://ufcstats.com/fighter-details/32feae6d9a1e5047
-Tatsuya Saika,--,155 lbs.,--,,"Sep 18, 1990",http://ufcstats.com/fighter-details/cc4e571964b084d4
-Chris Padilla,--,155 lbs.,--,,"Sep 14, 1995",http://ufcstats.com/fighter-details/06626b6287e1ae1e
-Li Yunfeng,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/4c7afd56ef1947ac
-Mansur Abdul-Malik,--,185 lbs.,--,,"Oct 07, 1997",http://ufcstats.com/fighter-details/841695e02c99a521
-Liam Anderson,--,185 lbs.,--,,"Jan 13, 1995",http://ufcstats.com/fighter-details/b03a0c78ca45facf
-Shannon Clark,--,125 lbs.,--,,"Jul 07, 1992",http://ufcstats.com/fighter-details/7ae36b3791e0969a
-William Currie,--,185 lbs.,--,,"Nov 12, 1998",http://ufcstats.com/fighter-details/b8ff02d5703eca3a
-Yuneisy Duben,--,125 lbs.,--,,--,http://ufcstats.com/fighter-details/c3d2b9bcb4cead6b
-Matthieu Duclos,--,185 lbs.,--,,--,http://ufcstats.com/fighter-details/ec322adbabbfa6e7
-Jack Duffy,--,125 lbs.,--,,"Oct 02, 1995",http://ufcstats.com/fighter-details/cea51876d8a514a0
-An Tuan Ho,--,125 lbs.,--,,"Sep 27, 2000",http://ufcstats.com/fighter-details/6c9384138c82962f
-Dominik Humburger,--,185 lbs.,--,,"Jan 03, 1996",http://ufcstats.com/fighter-details/e4cbc82c36e47299
-Lone'er Kavanagh,--,125 lbs.,--,,"Jun 09, 1999",http://ufcstats.com/fighter-details/bb2c3c3a466224af
-Andrey Pulyaev,--,185 lbs.,--,,"Sep 10, 1997",http://ufcstats.com/fighter-details/22e07d3da1aa3475
-Djorden Santos,--,185 lbs.,--,,"Aug 01, 1997",http://ufcstats.com/fighter-details/312f7d7b2b2f7de4
-Mikheil Sazhiniani,--,205 lbs.,--,,--,http://ufcstats.com/fighter-details/22a1f83edb865aee
-Wesley Schultz,--,185 lbs.,--,,"Aug 09, 1996",http://ufcstats.com/fighter-details/b4443fae47e7eb9d
-Nicolle Caliari,--,125 lbs.,--,,"Nov 04, 1996",http://ufcstats.com/fighter-details/fc0a4053eb8a3a59
-Raffael Cerqueira,--,205 lbs.,--,,"Mar 15, 1990",http://ufcstats.com/fighter-details/09a4447655fd4b7b
-Anvarbek Daniyalbekov,--,185 lbs.,--,,"May 27, 1995",http://ufcstats.com/fighter-details/859e0dafd04fe1ca
-Uran Satybaldiev,--,205 lbs.,--,,--,http://ufcstats.com/fighter-details/02f484417a6fa69d
-Alice Ardelean,--,115 lbs.,--,,"Apr 19, 1992",http://ufcstats.com/fighter-details/87f8699fdcc2c404
-Michael Aswell Jr.,--,145 lbs.,--,,"Sep 27, 2000",http://ufcstats.com/fighter-details/01c9e4013afce141
-Austin Bashi,--,135 lbs.,--,,"Sep 29, 2001",http://ufcstats.com/fighter-details/d3f89fa685bd8420
-Adam Bramhald,--,135 lbs.,--,,"Mar 24, 1994",http://ufcstats.com/fighter-details/3c99bd6cb5d835ef
-Billy Brand,--,135 lbs.,--,,"Jul 03, 1996",http://ufcstats.com/fighter-details/edae6db2b3453632
-Icaro Brito,--,145 lbs.,--,,"Mar 09, 1999",http://ufcstats.com/fighter-details/06dd61c8d545c63f
-Rose Conceicao,--,115 lbs.,--,,"May 13, 1997",http://ufcstats.com/fighter-details/a76c07e8e4c76e9a
-Islam Dulatov,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/e803242fb2e41112
-Andreas Gustafsson,--,185 lbs.,--,,"Feb 20, 1991",http://ufcstats.com/fighter-details/2caf993f53541fa1
-Michael Imperato,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/59e52d56bab2b1ee
-Ernie Juarez,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/410898e8dd6ca9b6
-Arthur Lopes,--,265 lbs.,--,,"Feb 17, 1993",http://ufcstats.com/fighter-details/2aa481e98185e261
-Tommy McMillen,--,145 lbs.,--,,"Dec 15, 1997",http://ufcstats.com/fighter-details/6b0a6def604de298
-Meng Ding,--,170 lbs.,--,,"Sep 26, 1994",http://ufcstats.com/fighter-details/e0664abaa023fd6f
-Josias Musasa,--,145 lbs.,--,,"Oct 10, 1999",http://ufcstats.com/fighter-details/723b64c0e9a8f348
-Pat Pytlik,--,170 lbs.,--,,"Apr 24, 1989",http://ufcstats.com/fighter-details/4fd140eea593526e
-Louis Lee Scott,--,135 lbs.,--,,"Feb 26, 2000",http://ufcstats.com/fighter-details/4327506eb9ee342f
-Otar Tanzilov,--,135 lbs.,--,,"Apr 09, 1998",http://ufcstats.com/fighter-details/b9124c308671e303
-Talisson Teixeira,--,265 lbs.,--,,"Dec 07, 1999",http://ufcstats.com/fighter-details/17923f676f100e16
-Malcolm Wellmaker,--,135 lbs.,--,,"Jun 04, 1994",http://ufcstats.com/fighter-details/2e45d08b3f2f02c8
-Gauge Young,--,170 lbs.,--,,"Jul 14, 2000",http://ufcstats.com/fighter-details/b2a78df161bd67f9
-Joilton Lutterbach,--,185 lbs.,--,,"Nov 05, 1992",http://ufcstats.com/fighter-details/12630a4aa0894da8
-Jose Ochoa,--,125 lbs.,--,,"Dec 31, 2000",http://ufcstats.com/fighter-details/88be62d6c1e6dadb
-Igor Cavalcanti,--,170 lbs.,--,,"Oct 10, 1997",http://ufcstats.com/fighter-details/9c3de7f8966326de
-Seok Hyeon Ko,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/4a6dff1b260bcf61
-Quemuel Ottoni,--,170 lbs.,--,,"Oct 22, 1992",http://ufcstats.com/fighter-details/7ce21433c2a53168
-Kody Steele,--,170 lbs.,--,,"Apr 21, 1995",http://ufcstats.com/fighter-details/aebaa8cec15b083d
-Seokhyeon Ko,--,170 lbs.,--,,--,http://ufcstats.com/fighter-details/4a07b1988477502c
-Cody Haddon,--,135 lbs.,--,,"Sep 08, 1998",http://ufcstats.com/fighter-details/8e6654e9f0461b8f
-Felipe Lima,--,145 lbs.,--,Orthodox,"May 07, 1998",http://ufcstats.com/fighter-details/9256f591b30c073e
-Kevin Christian,--,205 lbs.,--,,"Jan 21, 1995",http://ufcstats.com/fighter-details/7e9b36a9847db116
-Fatima Kline,--,115 lbs.,--,,"Jul 12, 2000",http://ufcstats.com/fighter-details/745fa7b605f8e2da
-Diyar Nurgozhay,--,205 lbs.,--,,--,http://ufcstats.com/fighter-details/709fadb644ee3f51
-Bailey Schoenfelder,--,265 lbs.,--,,"Sep 22, 1997",http://ufcstats.com/fighter-details/b0353e7f5038dd09
-Jose Heraldo Souza,--,185 lbs.,--,,"Dec 15, 1994",http://ufcstats.com/fighter-details/22b43be04d7454d0
-Navajo Stirling,--,205 lbs.,--,,"Nov 07, 1997",http://ufcstats.com/fighter-details/b4b496ec2197ee3e
-Bartosz Szewczyk,--,205 lbs.,--,,--,http://ufcstats.com/fighter-details/224050896306f00c
-Alexia Thainara,--,115 lbs.,--,,"Nov 20, 1997",http://ufcstats.com/fighter-details/545092d13c67aa49
-Alain Van der Merckt,--,185 lbs.,--,,"Jun 11, 1993",http://ufcstats.com/fighter-details/f6bbc6ba4f06ad60
-Danylo Voievodkin,--,265 lbs.,--,,--,http://ufcstats.com/fighter-details/d73a7c36746fbc5b
-Danylo Voievodkin,--,265 lbs.,--,,--,http://ufcstats.com/fighter-details/c2c4052f58f54988
-Lucas Camacho,--,265 lbs.,--,,"Dec 15, 1992",http://ufcstats.com/fighter-details/71d25689f70e4036
-Sean Gauci,--,125 lbs.,--,,"Oct 07, 1996",http://ufcstats.com/fighter-details/d758f272d94f5866
-Islem Masraf,--,265 lbs.,--,,--,http://ufcstats.com/fighter-details/6dedfe07640a9acc
-Danni McCormack,--,115 lbs.,--,,"Mar 15, 1990",http://ufcstats.com/fighter-details/2a9f9db24cd032ba
-Stewart Nicoll,--,125 lbs.,--,,"Nov 04, 1994",http://ufcstats.com/fighter-details/2bd98ab77a8daa75
-Mario Pinto,--,265 lbs.,--,,"Mar 14, 1998",http://ufcstats.com/fighter-details/39d309957c5c210d
-Artem Vakhitov,--,205 lbs.,--,,"Apr 04, 1991",http://ufcstats.com/fighter-details/43e549b803ec7375
-Patryk Grabowski,--,205 lbs.,--,,"Nov 12, 1995",http://ufcstats.com/fighter-details/4e163b53d1de1fbc
-Benjamin Bennett,--,170 lbs.,--,,"May 08, 1995",http://ufcstats.com/fighter-details/7030c27fc9778964
-Daniel Frunza,--,170 lbs.,--,,"Apr 13, 1994",http://ufcstats.com/fighter-details/7cec3c4a5e7b6d68
-Ateba Gautier,--,185 lbs.,--,,--,http://ufcstats.com/fighter-details/2f815ed5f8278ba6
-Joey Hart,--,170 lbs.,--,,"Jun 24, 1997",http://ufcstats.com/fighter-details/6412da484125716b
-Saygid Izagakhmaev,--,170 lbs.,--,,"Sep 03, 1994",http://ufcstats.com/fighter-details/de26d906f2874dd4
-Vadim Kutsy,--,170 lbs.,--,,"Jul 18, 1991",http://ufcstats.com/fighter-details/aeb2bcd4371f40d5
-Yura Naito,--,185 lbs.,--,,--,http://ufcstats.com/fighter-details/50c469e0cb73be10
-Luke Riley,--,145 lbs.,--,,"Jun 30, 1999",http://ufcstats.com/fighter-details/b1de86d835638319
-Aaron Tau,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/7abf7f8778472b7b
-Kai Asakura,--,135 lbs.,--,,"Oct 31, 1993",http://ufcstats.com/fighter-details/d33da8a3d82bdb62
-Ivan Erslan,--,205 lbs.,--,,"Nov 15, 1991",http://ufcstats.com/fighter-details/64ad3e3b0efa30bb
-Jordan Vucenic,--,155 lbs.,--,,"Mar 02, 1996",http://ufcstats.com/fighter-details/6d38e41efa47a72d
-Francesco Mazzeo,--,205 lbs.,--,,"Sep 23, 1997",http://ufcstats.com/fighter-details/7b3c13fe33556a21
-David Er-Ramy,--,205 lbs.,--,,"Sep 19, 1996",http://ufcstats.com/fighter-details/b593cd58b0afffb0
-Logan Woods,--,185 lbs.,--,,"May 30, 1994",http://ufcstats.com/fighter-details/133a9d2e6efd8a50
-Jose Delgado,--,145 lbs.,--,,--,http://ufcstats.com/fighter-details/7d6ceff6747f2de2
-Ryan Loder,--,185 lbs.,--,,"Jun 05, 1991",http://ufcstats.com/fighter-details/d5bab53a1a603aac
-Kaan Ofli,--,145 lbs.,--,,"Jun 19, 1993",http://ufcstats.com/fighter-details/7facc9c45d792985
-Jonathan Piersma,--,170 lbs.,--,,"Mar 03, 1996",http://ufcstats.com/fighter-details/1c7308d2957a12d2
-Leslie Hernandez,--,115 lbs.,--,,--,http://ufcstats.com/fighter-details/fc8610cc15674ae2
-Juliette Martinez,--,115 lbs.,--,,"Sep 14, 2004",http://ufcstats.com/fighter-details/f77afa72da84c9a8
-Nathan Fletcher,--,145 lbs.,--,,"Jan 03, 1998",http://ufcstats.com/fighter-details/a2d342ffc83913ed
-Taiga Iwasaki,--,185 lbs.,--,,"Jul 07, 1997",http://ufcstats.com/fighter-details/5b08af4fbc987f9c
-Zygimantas Ramaska,--,145 lbs.,--,,"Dec 27, 1996",http://ufcstats.com/fighter-details/641ca2c2ed91b93c
-Ramazan Temirov,--,125 lbs.,--,,"Jan 31, 1997",http://ufcstats.com/fighter-details/7d0a1968b38ca439
-Phil Latu,--,205 lbs.,--,,"Feb 17, 1991",http://ufcstats.com/fighter-details/09224b76d27007ee
-Robert Valentin Frey,--,185 lbs.,--,,"Mar 31, 1995",http://ufcstats.com/fighter-details/0cd0456d6029cec2
-Nick Piccininni,--,125 lbs.,--,,"Dec 16, 1996",http://ufcstats.com/fighter-details/a5cb1c29461853ca
-Mairon Santos,--,145 lbs.,--,,"Jun 10, 2000",http://ufcstats.com/fighter-details/480779d7f9a424d3
-Elijah Smith,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/7478b7f959ba61f5
-Cam Teague,--,145 lbs.,--,,"Feb 13, 1998",http://ufcstats.com/fighter-details/b47c9ea5f2895d6e
-Dorian Ramos,"5' 8""",145 lbs.,"70""",Orthodox,"Dec 31, 1993",http://ufcstats.com/fighter-details/fa4dcb2c8de482ee
-Christien Savoie,--,185 lbs.,--,,"Aug 29, 1992",http://ufcstats.com/fighter-details/67f0d1b1b0b39bec
-Jacobe Smith,--,170 lbs.,--,,"Jan 17, 1996",http://ufcstats.com/fighter-details/85497ffd934ecf7e
-Vanilto Antunes,--,170 lbs.,--,,"Dec 28, 1994",http://ufcstats.com/fighter-details/cc49ada1ea955b13
-Xavier Franklin,--,135 lbs.,--,,--,http://ufcstats.com/fighter-details/90957a918e26bf9c
-David Martinez,--,135 lbs.,--,,"Aug 03, 1998",http://ufcstats.com/fighter-details/9a97acbfd5a08bfa
-Mohamed Ado,--,170 lbs.,--,,"May 03, 2000",http://ufcstats.com/fighter-details/7a846fcbf182a7c8
-Yadier DelValle,--,155 lbs.,--,,"Jul 29, 1996",http://ufcstats.com/fighter-details/70380ccdc81915b8
-Jonathan Micallef,--,170 lbs.,--,,"Mar 05, 1999",http://ufcstats.com/fighter-details/f782f953bfe7b5f2
-Antonio Monteiro,--,145 lbs.,--,,"Jul 02, 1995",http://ufcstats.com/fighter-details/3e38b1ea16bd4d86
-Reinier de Ridder,--,205 lbs.,--,,"Sep 07, 1990",http://ufcstats.com/fighter-details/d549cefc7c54ab78
-Chasen Blair,--,155 lbs.,--,,--,http://ufcstats.com/fighter-details/0f4a536507f33576
-Carlos Calderon,--,145 lbs.,--,,"Feb 10, 1996",http://ufcstats.com/fighter-details/7d4d7583df7eebf9
-Luis Gurule,--,125 lbs.,--,,"Nov 16, 1993",http://ufcstats.com/fighter-details/29162be25ebef5f0
-Nick Klein,--,205 lbs.,--,,"Sep 08, 1995",http://ufcstats.com/fighter-details/7eaa5e31c2dd86aa
-Sean Sharaf,--,260 lbs.,--,,"Jul 11, 1993",http://ufcstats.com/fighter-details/0f3a990526c5e706
-Klaudia Sygula,--,135 lbs.,--,,"Dec 30, 1998",http://ufcstats.com/fighter-details/9f5e3c20ce40b344
-Carlos Leal,--,170 lbs.,--,Orthodox,"May 04, 1994",http://ufcstats.com/fighter-details/28d421729451c8ca


### PR DESCRIPTION
Re-ran existing script to pull new Fighter TOTT data from the website, which appears to have had some data gaps filled. Screenshot shows the missing rates before (above) and after (below) new scrape.

<img width="735" alt="image" src="https://github.com/user-attachments/assets/1460d0f2-c817-4e79-b9a6-1c3e1a9be79b">
